### PR TITLE
fix: Hide global header on mobile Tasks page

### DIFF
--- a/apps/web/src/components/Layout/index.tsx
+++ b/apps/web/src/components/Layout/index.tsx
@@ -1,16 +1,28 @@
-import { Outlet } from 'react-router-dom'
+import { Outlet, useLocation } from 'react-router-dom'
 import Header from './Header'
 import Footer from './Footer'
 import ToastContainer from '../ui/ToastContainer'
+import { useIsMobile } from '../../hooks/useIsMobile'
 
 export default function Layout() {
+  const location = useLocation()
+  const isMobile = useIsMobile()
+  
+  // Hide header on mobile for pages that have their own mobile-specific header
+  // Currently: /tasks and /quick-help (which redirects to /tasks)
+  const hideHeaderOnMobile = isMobile && (
+    location.pathname === '/tasks' || 
+    location.pathname === '/quick-help' ||
+    location.pathname.startsWith('/tasks?')
+  )
+
   return (
     <div className="min-h-screen flex flex-col">
-      <Header />
+      {!hideHeaderOnMobile && <Header />}
       <main className="flex-1">
         <Outlet />
       </main>
-      <Footer />
+      {!hideHeaderOnMobile && <Footer />}
       <ToastContainer />
     </div>
   )


### PR DESCRIPTION
## Problem
On mobile, the Tasks page was showing **two headers**:
1. The global "Kolab" header from the Layout component
2. The mobile-specific header from MobileTasksView (with search bar, filters, menu)

This caused the global header to cover/overlap the mobile controls.

## Solution
Hide the global Header (and Footer) on mobile when viewing the `/tasks` page, since MobileTasksView has its own complete mobile interface with:
- Hamburger menu
- Search bar
- Radius selector
- Category filters
- Notification bell

## Testing
- On mobile `/tasks`: Only the mobile-specific header should show
- On desktop `/tasks`: Global header should still show (desktop view doesn't have its own header)
- Other pages on mobile: Global header should still show