### PR TITLE
Fix: Show dispute button for both workers and creators at all allowed statuses

### DIFF
--- a/apps/web/src/pages/TaskDetail/components/TaskActionButtons.tsx
+++ b/apps/web/src/pages/TaskDetail/components/TaskActionButtons.tsx
@@ -15,6 +15,10 @@ interface TaskActionButtonsProps {
   onCancel: () => void;
 }
 
+// Match backend disputable statuses (app/routes/disputes.py)
+const WORKER_DISPUTABLE_STATUSES = ['assigned', 'in_progress', 'completed', 'pending_confirmation'];
+const CREATOR_DISPUTABLE_STATUSES = ['in_progress', 'completed', 'pending_confirmation'];
+
 export const TaskActionButtons = ({
   task,
   isCreator,
@@ -33,6 +37,11 @@ export const TaskActionButtons = ({
   const canMarkDone = isAssigned && (task.status === 'assigned' || task.status === 'in_progress');
   const canEdit = isCreator && task.status === 'open';
   const canApply = isAuthenticated && !isCreator && !isAssigned && task.status === 'open' && !hasApplied;
+
+  // Dispute visibility: match backend allowed statuses per role
+  const canDispute =
+    (isAssigned && WORKER_DISPUTABLE_STATUSES.includes(task.status)) ||
+    (isCreator && CREATOR_DISPUTABLE_STATUSES.includes(task.status));
 
   const getApplicationStatusLabel = (status: string) => {
     switch (status) {
@@ -76,22 +85,24 @@ export const TaskActionButtons = ({
 
         {/* Creator confirming */}
         {isCreator && task.status === 'pending_confirmation' && (
-          <>
-            <button
-              onClick={onConfirmDone}
-              disabled={actionLoading}
-              className="flex-1 bg-green-500 text-white py-3 rounded-xl hover:bg-green-600 disabled:bg-gray-400 font-bold text-sm shadow-lg active:scale-[0.98] transition-all"
-            >
-              {actionLoading ? 'Processing...' : '✓ Confirm'}
-            </button>
-            <button
-              onClick={onDispute}
-              disabled={actionLoading}
-              className="px-5 py-3 bg-orange-500 text-white rounded-xl hover:bg-orange-600 disabled:bg-gray-400 font-bold text-sm shadow-lg active:scale-[0.98] transition-all"
-            >
-              ⚠️ Dispute
-            </button>
-          </>
+          <button
+            onClick={onConfirmDone}
+            disabled={actionLoading}
+            className="flex-1 bg-green-500 text-white py-3 rounded-xl hover:bg-green-600 disabled:bg-gray-400 font-bold text-sm shadow-lg active:scale-[0.98] transition-all"
+          >
+            {actionLoading ? 'Processing...' : '✓ Confirm'}
+          </button>
+        )}
+
+        {/* Dispute button — visible for both roles at their allowed statuses */}
+        {canDispute && (
+          <button
+            onClick={onDispute}
+            disabled={actionLoading}
+            className="px-5 py-3 bg-orange-500 text-white rounded-xl hover:bg-orange-600 disabled:bg-gray-400 font-bold text-sm shadow-lg active:scale-[0.98] transition-all"
+          >
+            ⚠️ Dispute
+          </button>
         )}
 
         {/* Owner Edit/Cancel */}


### PR DESCRIPTION
## Problem

The dispute button was **only visible to the task creator at the `pending_confirmation` status**. This meant:
- **Workers could never see a dispute button**, even though the backend allows them to dispute from `assigned` onward (e.g., if the creator ghosts after accepting).
- **Creators could only dispute at `pending_confirmation`**, even though the backend allows them from `in_progress` onward.

## Fix

Extracted the dispute button into its own conditional block with a `canDispute` flag that mirrors the backend rules defined in `app/routes/disputes.py`:

| Role | Can dispute at |
|---|---|
| **Worker** | `assigned`, `in_progress`, `completed`, `pending_confirmation` |
| **Creator** | `in_progress`, `completed`, `pending_confirmation` |

The dispute button now appears **alongside** the existing action buttons (Mark as Done, Confirm, etc.) instead of being nested inside the creator-only confirm block.

## Changes

- `TaskActionButtons.tsx`: Added `WORKER_DISPUTABLE_STATUSES` and `CREATOR_DISPUTABLE_STATUSES` constants matching the backend, computed `canDispute`, and rendered the dispute button independently.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2FojayWillow%2Fmarketplace-frontend%2Fpull%2F58&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->