### PR TITLE
Fix: Star rating (only filled stars, SVG) + applications card layout cleanup

### DIFF
--- a/apps/web/src/pages/TaskDetail/TaskDetail.tsx
+++ b/apps/web/src/pages/TaskDetail/TaskDetail.tsx
@@ -42,16 +42,32 @@ import {
 import { useTaskActions } from './hooks';
 import { Review, CanReviewResponse } from './types';
 
-// StarRating helper component
+// StarRating: only shows filled stars (+ optional half), no empty stars
 const StarRating = ({ rating }: { rating: number }) => {
   const fullStars = Math.floor(rating);
-  const hasHalfStar = rating % 1 >= 0.5;
-  const emptyStars = 5 - fullStars - (hasHalfStar ? 1 : 0);
+  const hasHalfStar = rating % 1 >= 0.25;
+  const totalIcons = fullStars + (hasHalfStar ? 1 : 0);
+
+  if (totalIcons === 0) return null;
+
   return (
-    <span className="text-yellow-500 text-sm">
-      {'★'.repeat(fullStars)}
-      {hasHalfStar && '½'}
-      {'☆'.repeat(emptyStars)}
+    <span className="inline-flex items-center gap-px">
+      {Array.from({ length: fullStars }).map((_, i) => (
+        <svg key={`full-${i}`} className="w-3.5 h-3.5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+          <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+        </svg>
+      ))}
+      {hasHalfStar && (
+        <svg key="half" className="w-3.5 h-3.5 text-yellow-400" viewBox="0 0 20 20">
+          <defs>
+            <linearGradient id="halfGrad">
+              <stop offset="50%" stopColor="currentColor" />
+              <stop offset="50%" stopColor="#D1D5DB" />
+            </linearGradient>
+          </defs>
+          <path fill="url(#halfGrad)" d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+        </svg>
+      )}
     </span>
   );
 };

--- a/apps/web/src/pages/TaskDetail/components/TaskApplications.tsx
+++ b/apps/web/src/pages/TaskDetail/components/TaskApplications.tsx
@@ -21,82 +21,98 @@ export const TaskApplications = ({
   onMessage,
 }: TaskApplicationsProps) => {
   return (
-    <div className="mt-8">
-      <h2 className="text-xl font-semibold text-gray-900 mb-4 flex items-center gap-2">
-        📋 Applications
-        <span className="text-base font-normal text-gray-500">({applications.length})</span>
+    <div className="mt-4">
+      <h2 className="text-base font-semibold text-gray-900 mb-3 flex items-center gap-2">
+        \uD83D\uDCCB Applications
+        <span className="text-sm font-normal text-gray-500">({applications.length})</span>
       </h2>
 
       {applicationsLoading ? (
-        <div className="text-center py-8 text-gray-500">Loading applications...</div>
+        <div className="text-center py-6 text-gray-500 text-sm">Loading applications...</div>
       ) : applications.length === 0 ? (
-        <div className="text-center py-12 bg-blue-50 rounded-xl">
-          <span className="text-5xl mb-4 block">📋</span>
-          <p className="text-gray-700 font-medium">No applications yet</p>
-          <p className="text-gray-500 text-sm mt-1">Share your job to get more applicants!</p>
+        <div className="text-center py-8 bg-gray-50 rounded-xl">
+          <span className="text-3xl mb-2 block">\uD83D\uDCCB</span>
+          <p className="text-gray-600 font-medium text-sm">No applications yet</p>
+          <p className="text-gray-400 text-xs mt-1">Share your job to get more applicants!</p>
         </div>
       ) : (
-        <div className="space-y-3">
+        <div className="space-y-2.5">
           {applications.map(application => (
-            <div 
-              key={application.id} 
-              className={`border rounded-xl p-4 ${
-                application.status === 'pending' ? 'border-blue-200 bg-blue-50' 
-                : application.status === 'accepted' ? 'border-green-200 bg-green-50'
-                : 'border-gray-200 bg-gray-50'
+            <div
+              key={application.id}
+              className={`rounded-xl border overflow-hidden ${
+                application.status === 'pending' ? 'border-blue-100 bg-blue-50/50'
+                : application.status === 'accepted' ? 'border-green-100 bg-green-50/50'
+                : 'border-gray-100 bg-gray-50/50'
               }`}
             >
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex items-start gap-3 flex-1 min-w-0">
-                  <div className="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0 overflow-hidden">
+              {/* Applicant header */}
+              <div className="flex items-center gap-2.5 px-3.5 pt-3 pb-2">
+                <Link to={`/users/${application.applicant_id}`} className="flex-shrink-0">
+                  <div className="w-9 h-9 rounded-full bg-gradient-to-br from-blue-400 to-blue-600 flex items-center justify-center overflow-hidden">
                     {application.applicant_avatar ? (
-                      <img src={application.applicant_avatar} alt="" className="w-full h-full object-cover"/>
+                      <img src={application.applicant_avatar} alt="" className="w-full h-full object-cover" />
                     ) : (
-                      <span className="text-gray-500 font-medium">{application.applicant_name?.charAt(0).toUpperCase()}</span>
+                      <span className="text-white text-sm font-bold">
+                        {application.applicant_name?.charAt(0).toUpperCase()}
+                      </span>
                     )}
                   </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <Link to={`/users/${application.applicant_id}`} className="font-semibold text-gray-900 hover:text-blue-600">
-                        {application.applicant_name}
-                      </Link>
-                      {application.status === 'pending' && (
-                        <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700">Pending</span>
-                      )}
-                      {application.status === 'accepted' && (
-                        <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">✓ Accepted</span>
-                      )}
-                    </div>
-                    {application.message && (
-                      <p className="mt-2 text-sm text-gray-600 bg-white p-3 rounded-lg border">{application.message}</p>
-                    )}
-                  </div>
+                </Link>
+                <div className="flex-1 min-w-0">
+                  <Link
+                    to={`/users/${application.applicant_id}`}
+                    className="font-semibold text-sm text-gray-900 hover:text-blue-600 truncate block"
+                  >
+                    {application.applicant_name}
+                  </Link>
                 </div>
                 {application.status === 'pending' && (
-                  <div className="flex gap-2 flex-shrink-0">
-                    <button 
-                      onClick={() => onAccept(application.id)} 
-                      disabled={acceptingId === application.id} 
-                      className="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600 disabled:bg-gray-400 font-medium text-sm"
-                    >
-                      {acceptingId === application.id ? '...' : 'Accept'}
-                    </button>
-                    <button 
-                      onClick={() => onReject(application.id)} 
-                      disabled={rejectingId === application.id} 
-                      className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 text-sm"
-                    >
-                      Reject
-                    </button>
-                    <button 
-                      onClick={() => onMessage(application.applicant_id)} 
-                      className="px-3 py-2 bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 text-sm"
-                    >
-                      💬
-                    </button>
-                  </div>
+                  <span className="px-2 py-0.5 rounded-full text-[11px] font-semibold bg-yellow-100 text-yellow-700 flex-shrink-0">
+                    Pending
+                  </span>
+                )}
+                {application.status === 'accepted' && (
+                  <span className="px-2 py-0.5 rounded-full text-[11px] font-semibold bg-green-100 text-green-700 flex-shrink-0">
+                    \u2713 Accepted
+                  </span>
                 )}
               </div>
+
+              {/* Application message */}
+              {application.message && (
+                <div className="px-3.5 pb-2.5">
+                  <p className="text-sm text-gray-600 bg-white/80 rounded-lg px-3 py-2 border border-gray-100/80 leading-relaxed">
+                    {application.message}
+                  </p>
+                </div>
+              )}
+
+              {/* Action buttons — full width at bottom */}
+              {application.status === 'pending' && (
+                <div className="flex border-t border-gray-200/60">
+                  <button
+                    onClick={() => onAccept(application.id)}
+                    disabled={acceptingId === application.id}
+                    className="flex-1 py-2.5 text-sm font-semibold text-green-700 bg-green-50 hover:bg-green-100 disabled:text-gray-400 disabled:bg-gray-50 transition-colors border-r border-gray-200/60"
+                  >
+                    {acceptingId === application.id ? '...' : '\u2713 Accept'}
+                  </button>
+                  <button
+                    onClick={() => onReject(application.id)}
+                    disabled={rejectingId === application.id}
+                    className="flex-1 py-2.5 text-sm font-medium text-gray-500 hover:bg-gray-100 disabled:text-gray-300 transition-colors border-r border-gray-200/60"
+                  >
+                    Reject
+                  </button>
+                  <button
+                    onClick={() => onMessage(application.applicant_id)}
+                    className="px-5 py-2.5 text-sm font-medium text-blue-600 hover:bg-blue-50 transition-colors"
+                  >
+                    \uD83D\uDCAC
+                  </button>
+                </div>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Changes

### 1. Star Rating — no empty stars, proper SVG icons

**Before:** Text characters `★☆½` — empty stars always shown, half star was a literal "½" character.

**After:** Clean SVG star icons. Only filled stars are rendered (+ half star with gradient fill when applicable). A 3.5 rating shows 3 filled stars + 1 half star — nothing else. No empty gray stars cluttering the view.

### 2. Applications Card — clean stacked layout

**Before:** Avatar, name, status badge, and Accept/Reject/Message buttons all crammed into one horizontal row. On mobile, buttons overlapped the username.

**After:** Vertical stacked card layout:
- **Top:** Avatar + name + status badge in a clean header row
- **Middle:** Application message in a subtle card
- **Bottom:** Full-width tappable action strip (Accept | Reject | 💬) separated by a border — similar to iOS action sheet style

Much cleaner on mobile, no more overlapping or truncated names.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2FojayWillow%2Fmarketplace-frontend%2Fpull%2F59&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->