### PR TITLE
fix: Strip 'URGENT:' prefix from task titles — badge handles it

### DIFF
--- a/apps/web/src/pages/CreateTask/hooks/useTaskForm.ts
+++ b/apps/web/src/pages/CreateTask/hooks/useTaskForm.ts
@@ -4,6 +4,14 @@ import { useTranslation } from 'react-i18next';
 import { createTask, geocodeAddress, GeocodingResult, reverseGeocode, useAuthStore, useToastStore, uploadTaskImageFile } from '@marketplace/shared';
 import { TaskFormData, INITIAL_TASK_FORM } from '../types';
 
+/**
+ * Strip any "URGENT:" prefix the user may have typed.
+ * The is_urgent flag handles urgency — no need to bake it into the title.
+ */
+const stripUrgentPrefix = (title: string): string => {
+  return title.replace(/^URGENT:\s*/i, '').trim();
+};
+
 export const useTaskForm = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -175,7 +183,7 @@ export const useTaskForm = () => {
       }
 
       const taskData = {
-        title: formData.title,
+        title: stripUrgentPrefix(formData.title),
         description: formData.description,
         category: formData.category,
         location: formData.location,

--- a/apps/web/src/pages/WorkPage/components/WorkItemCard.tsx
+++ b/apps/web/src/pages/WorkPage/components/WorkItemCard.tsx
@@ -7,6 +7,14 @@ interface WorkItemCardProps {
   onClick: () => void;
 }
 
+/**
+ * Strip redundant "URGENT:" prefix from titles since the is_urgent flag
+ * already shows a 🔥 badge. Old tasks may have it baked into the title.
+ */
+const cleanTitle = (title: string): string => {
+  return title.replace(/^URGENT:\s*/i, '').trim();
+};
+
 const WorkItemCard = ({ item, categoryInfo, onClick }: WorkItemCardProps) => {
   const price = item.type === 'job' ? item.budget : item.price;
   const timeAgo = item.created_at ? formatTimeAgo(item.created_at) : '';
@@ -40,7 +48,7 @@ const WorkItemCard = ({ item, categoryInfo, onClick }: WorkItemCardProps) => {
       </div>
 
       {/* Title */}
-      <h3 className="text-sm font-bold text-gray-900 truncate mb-2">{item.title}</h3>
+      <h3 className="text-sm font-bold text-gray-900 truncate mb-2">{cleanTitle(item.title)}</h3>
 
       {/* Creator info */}
       <div className="flex gap-2 mb-2">


### PR DESCRIPTION
## Problem

Some tasks have "URGENT:" manually typed into the title AND `is_urgent: true` set. This causes a double indicator — the title says "URGENT: Document delivery to Jugla" AND there's a 🔥 Urgent badge next to the category.

## Fix

### Display (`WorkItemCard.tsx`)
Added a `cleanTitle()` helper that strips any `URGENT:` prefix (case-insensitive) from the displayed title. The `is_urgent` badge already handles the visual urgency indicator.

### Creation (`useTaskForm.ts`)
Added `stripUrgentPrefix()` that cleans the title before sending to the API. If a user types "URGENT: Fix my sink" and checks the urgent toggle, the title sent to the backend will be "Fix my sink" with `is_urgent: true`.

Existing tasks in the database still have "URGENT:" in their title text — this is a display-only fix. The old titles in the DB are untouched.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2FojayWillow%2Fmarketplace-frontend%2Fpull%2F62&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->