### PR TITLE
fix: eliminate white areas in dark mode on Messages and Work tabs (mobile web)

### DIFF
--- a/apps/mobile/app/(tabs)/messages.tsx
+++ b/apps/mobile/app/(tabs)/messages.tsx
@@ -77,8 +77,8 @@ export default function MessagesScreen() {
       </LinearGradient>
 
       <ScrollView
-        style={styles.scrollView}
-        contentContainerStyle={styles.scrollContent}
+        style={[styles.scrollView, { backgroundColor: themeColors.backgroundSecondary }]}
+        contentContainerStyle={[styles.scrollContent, { backgroundColor: themeColors.backgroundSecondary }]}
         refreshControl={
           <RefreshControl refreshing={isRefetching} onRefresh={refetch} />
         }

--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Prevent white flash / bleed-through in dark mode on mobile web */
+html, body, #root {
+  background-color: #0f172a;
+  min-height: 100%;
+}

--- a/apps/mobile/src/features/tasks/styles/tasksStyles.ts
+++ b/apps/mobile/src/features/tasks/styles/tasksStyles.ts
@@ -132,7 +132,9 @@ export const createStyles = (theme: 'light' | 'dark') => {
     },
     
     listContent: { 
-      padding: 16 
+      padding: 16,
+      flexGrow: 1,
+      backgroundColor: themeColors.backgroundSecondary,
     },
     centerContainer: { 
       alignItems: 'center', 


### PR DESCRIPTION
## Problem

In dark mode on mobile web view, large white areas appear at the bottom of:
1. **Messages tab** — below the conversation list when there are few conversations
2. **Work tab (Services view)** — below the service cards when results are few

This happens because the web document's `html`/`body` background defaults to white, and the React Native `ScrollView`/`FlatList` content areas don't fill the full viewport height when content is short.

## Root Cause

- `global.css` had no explicit background color for `html`/`body`/`#root`, so the web document defaults to white
- `messages.tsx` — the `ScrollView` and its `contentContainerStyle` had no `backgroundColor`, causing the underlying white body to bleed through
- `tasksStyles.ts` — the `listContent` style (used by FlatList) had only `{ padding: 16 }` with no background color or `flexGrow`, so FlatList content didn't extend to fill the viewport

## Changes

### 1. `apps/mobile/global.css`
- Added `html, body, #root { background-color: #0f172a; min-height: 100%; }` to match the dark theme background color at the document level

### 2. `apps/mobile/app/(tabs)/messages.tsx`
- Added `backgroundColor: themeColors.backgroundSecondary` to both the `ScrollView` `style` and `contentContainerStyle` props, ensuring the scroll area is fully painted in the correct dark background

### 3. `apps/mobile/src/features/tasks/styles/tasksStyles.ts`
- Added `flexGrow: 1` and `backgroundColor: themeColors.backgroundSecondary` to `listContent` style, ensuring the FlatList content area fills the viewport and uses the correct dark background

## Screenshots

Before (white areas visible below content):
- Messages tab: white gap below conversation list
- Work/Services tab: white gap below service cards

After: Full dark background coverage on both tabs regardless of content length.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2FojayWillow%2Fmarketplace-frontend%2Fpull%2F69&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->