### PR TITLE
fix: add dark:bg-gray-950 to mobile Layout wrapper — eliminates white areas in dark mode

### DIFF
--- a/apps/web/src/components/Layout/index.tsx
+++ b/apps/web/src/components/Layout/index.tsx
@@ -34,7 +34,7 @@ export default function Layout() {
   // safe-area-top handles iOS notch/Dynamic Island since there's no header to absorb it.
   if (showMobileBottomNav) {
     return (
-      <div className="min-h-screen bg-gray-50 safe-area-top">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-950 safe-area-top">
         <main className="pb-20">
           <Outlet />
         </main>
@@ -48,7 +48,7 @@ export default function Layout() {
   // Mobile layout WITHOUT bottom nav (auth pages, landing, etc)
   if (isMobile) {
     return (
-      <div className="min-h-screen flex flex-col">
+      <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-950">
         <Header />
         <main className="flex-1">
           <Outlet />
@@ -62,7 +62,7 @@ export default function Layout() {
 
   // Desktop layout: header + content + footer
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-950">
       <Header />
       <main className="flex-1">
         <Outlet />


### PR DESCRIPTION
## The Problem

White areas visible below content on the **Messages tab** and **Work/Services tab** when using dark mode on mobile web.

## Root Cause

The **single line** causing the issue — in `apps/web/src/components/Layout/index.tsx`:

```diff
- <div className="min-h-screen bg-gray-50 safe-area-top">
+ <div className="min-h-screen bg-gray-50 dark:bg-gray-950 safe-area-top">
```

The mobile layout wrapper had `bg-gray-50` (light background) but was **missing `dark:bg-gray-950`**. Since this `div` wraps ALL mobile pages (`<Outlet />`), it painted a light/white background behind every page. When page content was short (few messages, few services), the light parent background showed through below the content.

## Fix

Added `dark:bg-gray-950` to all three layout variants (mobile with nav, mobile without nav, desktop) for consistency.

## Previous Attempt

PR #69 fixed `apps/mobile/` files (the React Native/Expo app) — but the actual issue was in `apps/web/` (the Vite/React web app viewed on mobile phones).

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2FojayWillow%2Fmarketplace-frontend%2Fpull%2F70&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->