### PR TITLE
fix: send difficulty as 'difficulty' not 'priority' when creating task

### DIFF
--- a/apps/web/src/pages/CreateTask/hooks/useTaskForm.ts
+++ b/apps/web/src/pages/CreateTask/hooks/useTaskForm.ts
@@ -192,7 +192,7 @@ export const useTaskForm = () => {
         creator_id: user.id,
         budget: formData.budget ? parseFloat(formData.budget) : undefined,
         deadline,
-        priority: formData.difficulty,
+        difficulty: formData.difficulty,
         is_urgent: formData.is_urgent,
         image_urls: imageUrls.length > 0 ? imageUrls : undefined,
       };


### PR DESCRIPTION
## Problem
When creating a task and selecting **Hard** difficulty, the task always saved as **Medium**.

## Root Cause
In `useTaskForm.ts`, the submit payload mapped the difficulty value to the wrong key:
```diff
  const taskData = {
    ...
-   priority: formData.difficulty,
+   difficulty: formData.difficulty,
    ...
  };
```

The backend (`crud.py`) reads `data.get('difficulty', 'medium')`. Since the frontend was sending the value under `priority`, the backend never found `difficulty` in the payload and defaulted to `'medium'` every time.

The user's actual choice (e.g. `'hard'`) was silently stored in the `priority` field, which is a different concept entirely (normal/high/urgent).

## Fix
One-line change: `priority: formData.difficulty` → `difficulty: formData.difficulty`

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2FojayWillow%2Fmarketplace-frontend%2Fpull%2F71&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->