### PR TITLE
fix: replace priority/is_urgent with difficulty in EditTask form

### DIFF
--- a/apps/web/src/pages/EditTask/EditTask.tsx
+++ b/apps/web/src/pages/EditTask/EditTask.tsx
@@ -1,5 +1,5 @@
 import { useEditTaskForm } from './hooks';
-import { TASK_CATEGORIES, PRIORITY_OPTIONS } from './types';
+import { TASK_CATEGORIES, DIFFICULTY_OPTIONS } from './types';
 import { LocationInput, LoadingSpinner, NotFoundState } from './components';
 
 const EditTask = () => {
@@ -126,37 +126,22 @@ const EditTask = () => {
               />
             </div>
 
-            {/* Priority */}
+            {/* Difficulty */}
             <div>
-              <label htmlFor="priority" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                Priority
+              <label htmlFor="difficulty" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Difficulty
               </label>
               <select
-                id="priority"
-                name="priority"
-                value={formData.priority}
+                id="difficulty"
+                name="difficulty"
+                value={formData.difficulty}
                 onChange={handleChange}
                 className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               >
-                {PRIORITY_OPTIONS.map(opt => (
+                {DIFFICULTY_OPTIONS.map(opt => (
                   <option key={opt.value} value={opt.value}>{opt.label}</option>
                 ))}
               </select>
-            </div>
-
-            {/* Urgent Checkbox */}
-            <div className="flex items-center">
-              <input
-                type="checkbox"
-                id="is_urgent"
-                name="is_urgent"
-                checked={formData.is_urgent}
-                onChange={handleChange}
-                className="w-4 h-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded focus:ring-blue-500 dark:bg-gray-800"
-              />
-              <label htmlFor="is_urgent" className="ml-2 text-sm text-gray-700 dark:text-gray-300">
-                This is an urgent task
-              </label>
             </div>
 
             {/* Buttons */}

--- a/apps/web/src/pages/EditTask/hooks/useEditTaskForm.ts
+++ b/apps/web/src/pages/EditTask/hooks/useEditTaskForm.ts
@@ -51,8 +51,7 @@ export const useEditTaskForm = () => {
         latitude: task.latitude || 56.9496,
         longitude: task.longitude || 24.1052,
         deadline: task.deadline ? task.deadline.slice(0, 16) : '',
-        priority: task.priority || 'normal',
-        is_urgent: task.is_urgent || false,
+        difficulty: task.difficulty || 'medium',
       });
       setFormInitialized(true);
     }
@@ -138,8 +137,7 @@ export const useEditTaskForm = () => {
         longitude: formData.longitude,
         budget: formData.budget ? parseFloat(formData.budget) : undefined,
         deadline: formData.deadline || undefined,
-        priority: formData.priority,
-        is_urgent: formData.is_urgent,
+        difficulty: formData.difficulty,
       };
 
       await apiClient.put(`/api/tasks/${id}`, updateData);

--- a/apps/web/src/pages/EditTask/types.ts
+++ b/apps/web/src/pages/EditTask/types.ts
@@ -7,8 +7,7 @@ export interface EditTaskFormData {
   latitude: number;
   longitude: number;
   deadline: string;
-  priority: string;
-  is_urgent: boolean;
+  difficulty: 'easy' | 'medium' | 'hard';
 }
 
 export const INITIAL_EDIT_TASK_FORM: EditTaskFormData = {
@@ -20,8 +19,7 @@ export const INITIAL_EDIT_TASK_FORM: EditTaskFormData = {
   latitude: 56.9496,
   longitude: 24.1052,
   deadline: '',
-  priority: 'normal',
-  is_urgent: false,
+  difficulty: 'medium',
 };
 
 export const TASK_CATEGORIES = [
@@ -33,8 +31,8 @@ export const TASK_CATEGORIES = [
   { value: 'outdoor', label: '\uD83C\uDF3F Outdoor', icon: '\uD83C\uDF3F' },
 ] as const;
 
-export const PRIORITY_OPTIONS = [
-  { value: 'low', label: 'Low' },
-  { value: 'normal', label: 'Normal' },
-  { value: 'high', label: 'High' },
+export const DIFFICULTY_OPTIONS = [
+  { value: 'easy', label: 'Easy' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'hard', label: 'Hard' },
 ] as const;


### PR DESCRIPTION
## Problems
1. The Edit Task form shows an **"This is an urgent task"** checkbox that shouldn't be there — urgency is not a user-editable field on the edit form.
2. The form sends `priority` and `is_urgent` in the update payload, but the backend update endpoint (newly added) expects `difficulty`.
3. When loading an existing task, the form read `task.priority` instead of `task.difficulty`.

## Changes

### `types.ts`
- Replaced `priority: string` + `is_urgent: boolean` with `difficulty: 'easy' | 'medium' | 'hard'`
- Renamed `PRIORITY_OPTIONS` → `DIFFICULTY_OPTIONS` with values `easy`/`medium`/`hard`
- Updated initial form state

### `useEditTaskForm.ts`
- Form initialization reads `task.difficulty` instead of `task.priority`
- Submit payload sends `difficulty: formData.difficulty` instead of `priority` + `is_urgent`

### `EditTask.tsx`
- Removed the `is_urgent` checkbox entirely
- Replaced Priority dropdown with Difficulty dropdown
- Updated import from `PRIORITY_OPTIONS` → `DIFFICULTY_OPTIONS`

## Related
Backend counterpart: ojayWillow/marketplace-backend#15 (adds PUT endpoint)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2FojayWillow%2Fmarketplace-frontend%2Fpull%2F72&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->