### PR TITLE
Phase 1: Strip down Profile mobile layout to clean identity card

### DIFF
--- a/apps/web/src/pages/Profile/Profile.tsx
+++ b/apps/web/src/pages/Profile/Profile.tsx
@@ -23,8 +23,6 @@ import {
   useProfileActions,
 } from './hooks';
 import { MobileReviewsSection } from './components/mobile/MobileReviewsSection';
-import { MobileActivitySection } from './components/mobile/MobileActivitySection';
-import { MobileListingsTeaser } from './components/mobile/MobileListingsTeaser';
 import CommunityRulesModal from '../../components/QuickHelpIntroModal';
 
 const Profile = () => {
@@ -75,7 +73,6 @@ const Profile = () => {
     setFormData,
   });
 
-  const [mobileActivityMode, setMobileActivityMode] = useState<'jobs' | 'services'>('jobs');
   const [showAllReviews, setShowAllReviews] = useState(false);
   const [showMobileSettings, setShowMobileSettings] = useState(false);
 
@@ -130,7 +127,7 @@ const Profile = () => {
   const hasTasks = createdTasks.length > 0 || myApplications.length > 0;
   const hasReviews = reviews.length > 0;
 
-  // Mobile layout
+  // Mobile layout — clean identity card + reviews only
   if (isMobile) {
     return (
       <div className="flex flex-col flex-1 bg-gray-50 dark:bg-gray-950 animate-page-enter">
@@ -207,29 +204,6 @@ const Profile = () => {
                       onDeleteReview={actions.handleDeleteReview}
                       setReviews={setReviews}
                     />
-
-                    <MobileListingsTeaser />
-
-                    <MobileActivitySection
-                      activeMode={mobileActivityMode}
-                      onModeChange={setMobileActivityMode}
-                      createdTasks={createdTasks}
-                      myApplications={myApplications}
-                      taskMatchCounts={taskMatchCounts}
-                      tasksLoading={tasksLoading}
-                      applicationsLoading={applicationsLoading}
-                      taskViewMode={taskViewMode}
-                      taskStatusFilter={taskStatusFilter}
-                      onViewModeChange={setTaskViewMode}
-                      onStatusFilterChange={setTaskStatusFilter}
-                      onCancelTask={actions.handleCancelTask}
-                      onTaskConfirmed={fetchTasks}
-                      userId={user?.id}
-                      offerings={myOfferings}
-                      offeringsLoading={offeringsLoading}
-                      onDeleteOffering={actions.handleDeleteOffering}
-                      pendingNotifications={totalPendingApplicationsOnMyTasks}
-                    />
                   </>
                 )}
               </>
@@ -240,7 +214,7 @@ const Profile = () => {
     );
   }
 
-  // Desktop layout
+  // Desktop layout — unchanged
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950 py-6 animate-page-enter">
       <div className="max-w-4xl mx-auto px-4">


### PR DESCRIPTION
## What this does
Cleans up the Profile page mobile layout by removing work management components that will move to the Work tab (Phase 2).

Closes #73

## Changes

### `apps/web/src/pages/Profile/Profile.tsx`
- **Removed** `<MobileListingsTeaser />` from mobile render (the "Sludinājumi DRĪZ" banner)
- **Removed** `<MobileActivitySection />` from mobile render (Darbi/Pakalpojumi toggles, sub-tabs, task/offering cards)
- **Removed** `mobileActivityMode` state (only used by MobileActivitySection)
- **Removed** corresponding imports
- **Kept** all data hooks — desktop Profile tabs still use them
- **Desktop layout is completely untouched**

### What the mobile Profile now shows:
1. ✅ ProfileHeader (avatar, name, stats, edit, settings gear)
2. ✅ MobileReviewsSection (collapsed reviews with "See all")
3. ✅ AboutTab (when editing)
4. ✅ Settings view (when gear tapped)
5. ✅ AvatarPicker modal
6. ✅ CommunityRulesModal

### What was removed from mobile Profile:
- ❌ MobileListingsTeaser — will be added to Settings as "Coming Soon" in follow-up
- ❌ MobileActivitySection — moves to Work tab in Phase 2 (#74)

## Component files preserved
- `MobileActivitySection.tsx` — NOT deleted, needed for Phase 2
- `MobileListingsTeaser.tsx` — NOT deleted, may be reused

## Testing
- [ ] Mobile Profile loads and shows identity card + reviews
- [ ] Edit mode works (AboutTab appears)
- [ ] Settings gear opens SettingsTab
- [ ] Desktop Profile is completely unchanged
- [ ] No TypeScript errors

## Next steps
- Phase 2: Add "Mans" tab to Work page (#74)
- Phase 3: Polish — SVG icons, badges (#75)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2FojayWillow%2Fmarketplace-frontend%2Fpull%2F76&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->