### PR TITLE
Phase 2: Add "Mans" (Mine) tab to Work page

### DIFF
--- a/apps/web/src/hooks/useMyWork.ts
+++ b/apps/web/src/hooks/useMyWork.ts
@@ -1,0 +1,145 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useAuthStore } from '@marketplace/shared';
+import { apiClient } from '@marketplace/shared';
+import { useToastStore } from '@marketplace/shared';
+import { cancelTask, confirmTaskCompletion } from '@marketplace/shared';
+import { deleteOffering } from '@marketplace/shared';
+import type { Task, TaskApplication, TaskMatchCounts, TaskViewMode, TaskStatusFilter } from '@marketplace/shared';
+import type { Offering } from '@marketplace/shared';
+
+/**
+ * Shared hook for "my work" data — tasks I created, tasks I applied to, my offerings.
+ * Used by both WorkPage (Mine tab) and Profile (desktop tabs).
+ */
+export const useMyWork = () => {
+  const { isAuthenticated, user } = useAuthStore();
+  const toast = useToastStore();
+
+  // Data
+  const [createdTasks, setCreatedTasks] = useState<Task[]>([]);
+  const [myApplications, setMyApplications] = useState<TaskApplication[]>([]);
+  const [myOfferings, setMyOfferings] = useState<Offering[]>([]);
+  const [taskMatchCounts, setTaskMatchCounts] = useState<TaskMatchCounts>({});
+
+  // Loading
+  const [loading, setLoading] = useState(true);
+  const [tasksLoading, setTasksLoading] = useState(false);
+  const [applicationsLoading, setApplicationsLoading] = useState(false);
+  const [offeringsLoading, setOfferingsLoading] = useState(false);
+
+  // Tab/filter state for "my work" view
+  const [activeMode, setActiveMode] = useState<'jobs' | 'services'>('jobs');
+  const [taskViewMode, setTaskViewMode] = useState<TaskViewMode>('my-tasks');
+  const [taskStatusFilter, setTaskStatusFilter] = useState<TaskStatusFilter>('all');
+
+  // Fetch functions
+  const fetchTasks = useCallback(async () => {
+    setTasksLoading(true);
+    try {
+      const response = await apiClient.get('/api/tasks/created');
+      setCreatedTasks(response.data.tasks || []);
+    } catch (e) {
+      console.error('Error fetching tasks:', e);
+    } finally {
+      setTasksLoading(false);
+    }
+  }, []);
+
+  const fetchApplications = useCallback(async () => {
+    setApplicationsLoading(true);
+    try {
+      const response = await apiClient.get('/api/tasks/applications/mine');
+      setMyApplications(response.data.applications || []);
+    } catch (e) {
+      console.error('Error fetching applications:', e);
+    } finally {
+      setApplicationsLoading(false);
+    }
+  }, []);
+
+  const fetchOfferings = useCallback(async () => {
+    setOfferingsLoading(true);
+    try {
+      const response = await apiClient.get('/api/offerings/mine');
+      setMyOfferings(response.data.offerings || []);
+    } catch (e) {
+      console.error('Error fetching offerings:', e);
+    } finally {
+      setOfferingsLoading(false);
+    }
+  }, []);
+
+  // Load all data
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    await Promise.all([fetchTasks(), fetchApplications(), fetchOfferings()]);
+    setLoading(false);
+  }, [fetchTasks, fetchApplications, fetchOfferings]);
+
+  // Actions
+  const handleCancelTask = useCallback(async (taskId: number) => {
+    if (!window.confirm('Are you sure you want to cancel this task?')) return;
+    try {
+      await cancelTask(taskId);
+      toast.success('Task cancelled');
+      fetchTasks();
+    } catch (error) {
+      console.error('Error cancelling task:', error);
+      toast.error('Failed to cancel task');
+    }
+  }, [fetchTasks, toast]);
+
+  const handleDeleteOffering = useCallback(async (offeringId: number) => {
+    if (!window.confirm('Are you sure you want to delete this service offering?')) return;
+    try {
+      await deleteOffering(offeringId);
+      setMyOfferings(prev => prev.filter(o => o.id !== offeringId));
+      toast.success('Offering deleted successfully');
+    } catch (error) {
+      console.error('Error deleting offering:', error);
+      toast.error('Failed to delete offering');
+    }
+  }, [toast]);
+
+  // Computed values
+  const totalPendingApplicationsOnMyTasks = createdTasks.reduce((sum, task) => {
+    return sum + (task.pending_applications_count || 0);
+  }, 0);
+
+  return {
+    // Data
+    createdTasks,
+    myApplications,
+    myOfferings,
+    setMyOfferings,
+    taskMatchCounts,
+    userId: user?.id,
+
+    // Loading
+    loading,
+    tasksLoading,
+    applicationsLoading,
+    offeringsLoading,
+
+    // Tab/filter state
+    activeMode,
+    setActiveMode,
+    taskViewMode,
+    setTaskViewMode,
+    taskStatusFilter,
+    setTaskStatusFilter,
+
+    // Fetchers
+    fetchAll,
+    fetchTasks,
+    fetchApplications,
+    fetchOfferings,
+
+    // Actions
+    handleCancelTask,
+    handleDeleteOffering,
+
+    // Computed
+    totalPendingApplicationsOnMyTasks,
+  };
+};

--- a/apps/web/src/pages/WorkPage/WorkPage.tsx
+++ b/apps/web/src/pages/WorkPage/WorkPage.tsx
@@ -10,6 +10,8 @@ import {
   ErrorState,
   EmptyState,
   InlineError,
+  WorkFAB,
+  MyWorkDashboard,
 } from './components';
 
 const WorkPage = () => {
@@ -31,7 +33,71 @@ const WorkPage = () => {
     handleItemClick,
     handleRetry,
     getCategoryInfo,
+    myWork,
   } = useWorkPage();
+
+  const isMineTab = mainTab === 'mine';
+
+  // Marketplace feed content (shared between mobile and desktop)
+  const renderMarketplaceFeed = () => (
+    <>
+      {initialLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <SkeletonCard key={i} />
+          ))}
+        </div>
+      ) : error && items.length === 0 ? (
+        <ErrorState error={error} onRetry={handleRetry} />
+      ) : itemsWithDistance.length === 0 ? (
+        <EmptyState mainTab={mainTab} hasFilters={selectedCategories.length > 0} />
+      ) : (
+        <>
+          {error && <InlineError error={error} onRetry={handleRetry} />}
+          <div className="space-y-2">
+            {itemsWithDistance.map((item, index) => (
+              <div
+                key={`${item.type}-${item.id}`}
+                className="animate-fade-in-up"
+                style={{ animationDelay: `${Math.min(index * 50, 300)}ms` }}
+              >
+                <WorkItemCard
+                  item={item}
+                  categoryInfo={getCategoryInfo(item.category)}
+                  onClick={() => handleItemClick(item)}
+                />
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </>
+  );
+
+  // Mine tab content
+  const renderMyWork = () => (
+    <MyWorkDashboard
+      activeMode={myWork.activeMode}
+      onModeChange={myWork.setActiveMode}
+      createdTasks={myWork.createdTasks}
+      myApplications={myWork.myApplications}
+      taskMatchCounts={myWork.taskMatchCounts}
+      tasksLoading={myWork.tasksLoading}
+      applicationsLoading={myWork.applicationsLoading}
+      taskViewMode={myWork.taskViewMode}
+      taskStatusFilter={myWork.taskStatusFilter}
+      onViewModeChange={myWork.setTaskViewMode}
+      onStatusFilterChange={myWork.setTaskStatusFilter}
+      onCancelTask={myWork.handleCancelTask}
+      onTaskConfirmed={myWork.fetchTasks}
+      userId={myWork.userId}
+      offerings={myWork.myOfferings}
+      offeringsLoading={myWork.offeringsLoading}
+      onDeleteOffering={myWork.handleDeleteOffering}
+      pendingNotifications={myWork.totalPendingApplicationsOnMyTasks}
+      loading={myWork.loading}
+    />
+  );
 
   // Mobile: flex layout that fills the space from fullscreen Layout
   if (isMobile) {
@@ -57,40 +123,14 @@ const WorkPage = () => {
           initialLoading={initialLoading}
           hasError={!!error}
           hasUserLocation={!!userLocation}
+          pendingNotifications={myWork.totalPendingApplicationsOnMyTasks}
         />
 
         <div className="flex-1 overflow-y-auto px-4 py-4">
-          {initialLoading ? (
-            <div className="space-y-2">
-              {Array.from({ length: 4 }).map((_, i) => (
-                <SkeletonCard key={i} />
-              ))}
-            </div>
-          ) : error && items.length === 0 ? (
-            <ErrorState error={error} onRetry={handleRetry} />
-          ) : itemsWithDistance.length === 0 ? (
-            <EmptyState mainTab={mainTab} hasFilters={selectedCategories.length > 0} />
-          ) : (
-            <>
-              {error && <InlineError error={error} onRetry={handleRetry} />}
-              <div className="space-y-2">
-                {itemsWithDistance.map((item, index) => (
-                  <div
-                    key={`${item.type}-${item.id}`}
-                    className="animate-fade-in-up"
-                    style={{ animationDelay: `${Math.min(index * 50, 300)}ms` }}
-                  >
-                    <WorkItemCard
-                      item={item}
-                      categoryInfo={getCategoryInfo(item.category)}
-                      onClick={() => handleItemClick(item)}
-                    />
-                  </div>
-                ))}
-              </div>
-            </>
-          )}
+          {isMineTab ? renderMyWork() : renderMarketplaceFeed()}
         </div>
+
+        <WorkFAB />
       </div>
     );
   }
@@ -118,40 +158,14 @@ const WorkPage = () => {
         initialLoading={initialLoading}
         hasError={!!error}
         hasUserLocation={!!userLocation}
+        pendingNotifications={myWork.totalPendingApplicationsOnMyTasks}
       />
 
       <div className="px-4 py-4">
-        {initialLoading ? (
-          <div className="space-y-2">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <SkeletonCard key={i} />
-            ))}
-          </div>
-        ) : error && items.length === 0 ? (
-          <ErrorState error={error} onRetry={handleRetry} />
-        ) : itemsWithDistance.length === 0 ? (
-          <EmptyState mainTab={mainTab} hasFilters={selectedCategories.length > 0} />
-        ) : (
-          <>
-            {error && <InlineError error={error} onRetry={handleRetry} />}
-            <div className="space-y-2">
-              {itemsWithDistance.map((item, index) => (
-                <div
-                  key={`${item.type}-${item.id}`}
-                  className="animate-fade-in-up"
-                  style={{ animationDelay: `${Math.min(index * 50, 300)}ms` }}
-                >
-                  <WorkItemCard
-                    item={item}
-                    categoryInfo={getCategoryInfo(item.category)}
-                    onClick={() => handleItemClick(item)}
-                  />
-                </div>
-              ))}
-            </div>
-          </>
-        )}
+        {isMineTab ? renderMyWork() : renderMarketplaceFeed()}
       </div>
+
+      <WorkFAB />
     </div>
   );
 };

--- a/apps/web/src/pages/WorkPage/components/MyWorkDashboard.tsx
+++ b/apps/web/src/pages/WorkPage/components/MyWorkDashboard.tsx
@@ -1,0 +1,130 @@
+import { useTranslation } from 'react-i18next';
+import { TasksTab } from '../../Profile/components/tabs/TasksTab';
+import { OfferingsTab } from '../../Profile/components/tabs/OfferingsTab';
+import type { Task, TaskApplication, TaskViewMode, TaskStatusFilter, TaskMatchCounts } from '@marketplace/shared';
+import type { Offering } from '@marketplace/shared';
+
+interface MyWorkDashboardProps {
+  activeMode: 'jobs' | 'services';
+  onModeChange: (mode: 'jobs' | 'services') => void;
+  createdTasks: Task[];
+  myApplications: TaskApplication[];
+  taskMatchCounts: TaskMatchCounts;
+  tasksLoading: boolean;
+  applicationsLoading: boolean;
+  taskViewMode: TaskViewMode;
+  taskStatusFilter: TaskStatusFilter;
+  onViewModeChange: (mode: TaskViewMode) => void;
+  onStatusFilterChange: (filter: TaskStatusFilter) => void;
+  onCancelTask?: (id: number) => void;
+  onTaskConfirmed?: () => void;
+  userId?: number;
+  offerings: Offering[];
+  offeringsLoading: boolean;
+  onDeleteOffering?: (id: number) => void;
+  pendingNotifications: number;
+  loading: boolean;
+}
+
+const MyWorkDashboard = ({
+  activeMode,
+  onModeChange,
+  createdTasks,
+  myApplications,
+  taskMatchCounts,
+  tasksLoading,
+  applicationsLoading,
+  taskViewMode,
+  taskStatusFilter,
+  onViewModeChange,
+  onStatusFilterChange,
+  onCancelTask,
+  onTaskConfirmed,
+  userId,
+  offerings,
+  offeringsLoading,
+  onDeleteOffering,
+  pendingNotifications,
+  loading,
+}: MyWorkDashboardProps) => {
+  const { t } = useTranslation();
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="flex flex-col items-center gap-3">
+          <div className="w-10 h-10 border-4 border-blue-200 border-t-blue-500 rounded-full animate-spin" />
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {t('common.loading', 'Loading...')}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Jobs / Services toggle */}
+      <div className="flex items-center gap-2 mb-4">
+        <div className="flex gap-1 flex-1 bg-gray-100 dark:bg-gray-800 p-1 rounded-lg">
+          <button
+            onClick={() => onModeChange('jobs')}
+            className={`flex-1 px-3 py-2 rounded-md text-sm font-medium transition-all relative ${
+              activeMode === 'jobs'
+                ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
+                : 'text-gray-600 dark:text-gray-400'
+            }`}
+          >
+            {t('profile.tabs.jobs', 'Jobs')}
+            {pendingNotifications > 0 && (
+              <span className="absolute -top-1 -right-1 px-1.5 py-0.5 text-[10px] rounded-full bg-red-500 text-white font-bold min-w-[18px] text-center">
+                {pendingNotifications}
+              </span>
+            )}
+          </button>
+          <button
+            onClick={() => onModeChange('services')}
+            className={`flex-1 px-3 py-2 rounded-md text-sm font-medium transition-all ${
+              activeMode === 'services'
+                ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
+                : 'text-gray-600 dark:text-gray-400'
+            }`}
+          >
+            {t('profile.tabs.services', 'Services')}
+            {offerings.length > 0 && (
+              <span className="text-gray-400 dark:text-gray-500 ml-1 text-xs">({offerings.length})</span>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      {activeMode === 'jobs' ? (
+        <TasksTab
+          createdTasks={createdTasks}
+          myApplications={myApplications}
+          taskMatchCounts={taskMatchCounts}
+          tasksLoading={tasksLoading}
+          applicationsLoading={applicationsLoading}
+          taskViewMode={taskViewMode}
+          taskStatusFilter={taskStatusFilter}
+          onViewModeChange={onViewModeChange}
+          onStatusFilterChange={onStatusFilterChange}
+          onCancelTask={onCancelTask}
+          onTaskConfirmed={onTaskConfirmed}
+          userId={userId}
+          compact
+        />
+      ) : (
+        <OfferingsTab
+          offerings={offerings}
+          loading={offeringsLoading}
+          onDelete={onDeleteOffering}
+          compact
+        />
+      )}
+    </div>
+  );
+};
+
+export default MyWorkDashboard;

--- a/apps/web/src/pages/WorkPage/components/TabBar.tsx
+++ b/apps/web/src/pages/WorkPage/components/TabBar.tsx
@@ -11,6 +11,7 @@ interface TabBarProps {
   initialLoading: boolean;
   hasError: boolean;
   hasUserLocation: boolean;
+  pendingNotifications?: number;
 }
 
 const TabBar = ({
@@ -23,56 +24,69 @@ const TabBar = ({
   initialLoading,
   hasError,
   hasUserLocation,
+  pendingNotifications = 0,
 }: TabBarProps) => {
   const { t } = useTranslation();
+
+  const isMineTab = mainTab === 'mine';
 
   return (
     <div className="sticky top-0 bg-white dark:bg-gray-900 shadow-sm dark:shadow-gray-900/50 z-50">
       <div className="relative flex items-center justify-center px-4 py-3">
         <div className="flex gap-2">
-          {(['all', 'jobs', 'services'] as MainTab[]).map((tab) => (
+          {(['all', 'jobs', 'services', 'mine'] as MainTab[]).map((tab) => (
             <button
               key={tab}
               onClick={() => onTabChange(tab)}
-              className={`px-4 py-2 rounded-full text-sm font-medium transition-all ${
+              className={`relative px-4 py-2 rounded-full text-sm font-medium transition-all ${
                 mainTab === tab
-                  ? 'bg-blue-500 text-white'
+                  ? tab === 'mine'
+                    ? 'bg-amber-500 text-white'
+                    : 'bg-blue-500 text-white'
                   : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300'
               }`}
             >
-              {t(
-                `tasks.tab${tab.charAt(0).toUpperCase() + tab.slice(1)}`
+              {tab === 'mine'
+                ? t('work.tabMine', 'Mans')
+                : t(`tasks.tab${tab.charAt(0).toUpperCase() + tab.slice(1)}`)}
+              {tab === 'mine' && pendingNotifications > 0 && (
+                <span className="absolute -top-1 -right-1 px-1.5 py-0.5 text-[10px] rounded-full bg-red-500 text-white font-bold min-w-[18px] text-center">
+                  {pendingNotifications}
+                </span>
               )}
             </button>
           ))}
         </div>
 
-        <button
-          onClick={onFilterClick}
-          className="absolute right-4 flex items-center justify-center w-10 h-10 bg-gray-100 dark:bg-gray-800 rounded-full"
-          aria-label={t('tasks.filters', 'Filter')}
-        >
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-gray-700 dark:text-gray-300">
-            <line x1="4" y1="21" x2="4" y2="14" />
-            <line x1="4" y1="10" x2="4" y2="3" />
-            <line x1="12" y1="21" x2="12" y2="12" />
-            <line x1="12" y1="8" x2="12" y2="3" />
-            <line x1="20" y1="21" x2="20" y2="16" />
-            <line x1="20" y1="12" x2="20" y2="3" />
-            <line x1="1" y1="14" x2="7" y2="14" />
-            <line x1="9" y1="8" x2="15" y2="8" />
-            <line x1="17" y1="16" x2="23" y2="16" />
-          </svg>
-          {selectedCategoryCount > 0 && (
-            <span className="absolute -top-1 -right-1 w-5 h-5 bg-blue-500 text-white text-xs font-bold rounded-full flex items-center justify-center">
-              {selectedCategoryCount}
-            </span>
-          )}
-        </button>
+        {/* Filter button — hidden when in Mine tab (Mine has its own sub-filters) */}
+        {!isMineTab && (
+          <button
+            onClick={onFilterClick}
+            className="absolute right-4 flex items-center justify-center w-10 h-10 bg-gray-100 dark:bg-gray-800 rounded-full"
+            aria-label={t('tasks.filters', 'Filter')}
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-gray-700 dark:text-gray-300">
+              <line x1="4" y1="21" x2="4" y2="14" />
+              <line x1="4" y1="10" x2="4" y2="3" />
+              <line x1="12" y1="21" x2="12" y2="12" />
+              <line x1="12" y1="8" x2="12" y2="3" />
+              <line x1="20" y1="21" x2="20" y2="16" />
+              <line x1="20" y1="12" x2="20" y2="3" />
+              <line x1="1" y1="14" x2="7" y2="14" />
+              <line x1="9" y1="8" x2="15" y2="8" />
+              <line x1="17" y1="16" x2="23" y2="16" />
+            </svg>
+            {selectedCategoryCount > 0 && (
+              <span className="absolute -top-1 -right-1 w-5 h-5 bg-blue-500 text-white text-xs font-bold rounded-full flex items-center justify-center">
+                {selectedCategoryCount}
+              </span>
+            )}
+          </button>
+        )}
       </div>
 
-      {/* Result count with loading spinner */}
-      {!initialLoading && !hasError && itemCount > 0 && (
+      {/* Result count — only for marketplace tabs */}
+      {!isMineTab && !initialLoading && !hasError && itemCount > 0 && (
         <div className="px-4 pb-2 flex items-center justify-center gap-1">
           {refreshing && (
             <span className="inline-block animate-spin text-blue-500 text-sm">↻</span>

--- a/apps/web/src/pages/WorkPage/components/WorkFAB.tsx
+++ b/apps/web/src/pages/WorkPage/components/WorkFAB.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+const WorkFAB = () => {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      {/* Backdrop */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 bg-black/20 backdrop-blur-[1px] z-40"
+          onClick={() => setIsOpen(false)}
+        />
+      )}
+
+      {/* FAB menu options */}
+      <div className="fixed bottom-24 right-4 z-50 flex flex-col items-end gap-3">
+        {isOpen && (
+          <>
+            {/* Post a job */}
+            <div className="flex items-center gap-2 animate-fade-in-up" style={{ animationDelay: '0ms' }}>
+              <span className="px-3 py-1.5 bg-white dark:bg-gray-800 rounded-lg shadow-lg text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                {t('work.fab.postJob', 'Publicēt darbu')}
+              </span>
+              <Link
+                to="/tasks/create"
+                className="w-12 h-12 flex items-center justify-center bg-blue-500 text-white rounded-full shadow-lg hover:bg-blue-600 transition-colors"
+                onClick={() => setIsOpen(false)}
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+              </Link>
+            </div>
+
+            {/* Offer a service */}
+            <div className="flex items-center gap-2 animate-fade-in-up" style={{ animationDelay: '50ms' }}>
+              <span className="px-3 py-1.5 bg-white dark:bg-gray-800 rounded-lg shadow-lg text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                {t('work.fab.offerService', 'Piedāvāt pakalpojumu')}
+              </span>
+              <Link
+                to="/offerings/create"
+                className="w-12 h-12 flex items-center justify-center bg-amber-500 text-white rounded-full shadow-lg hover:bg-amber-600 transition-colors"
+                onClick={() => setIsOpen(false)}
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+                </svg>
+              </Link>
+            </div>
+          </>
+        )}
+
+        {/* Main FAB button */}
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          className={`w-14 h-14 flex items-center justify-center rounded-full shadow-xl transition-all duration-200 ${
+            isOpen
+              ? 'bg-gray-600 rotate-45'
+              : 'bg-blue-600 hover:bg-blue-700'
+          }`}
+          aria-label={t('work.fab.create', 'Create')}
+        >
+          <svg className="w-7 h-7 text-white transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+          </svg>
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default WorkFAB;

--- a/apps/web/src/pages/WorkPage/components/index.ts
+++ b/apps/web/src/pages/WorkPage/components/index.ts
@@ -1,4 +1,7 @@
+export { default as TabBar } from './TabBar';
 export { default as SkeletonCard } from './SkeletonCard';
 export { default as WorkItemCard } from './WorkItemCard';
-export { default as TabBar } from './TabBar';
-export { ErrorState, EmptyState, InlineError } from './EmptyState';
+export { default as WorkFAB } from './WorkFAB';
+export { default as MyWorkDashboard } from './MyWorkDashboard';
+export { ErrorState, InlineError } from './EmptyState';
+export { EmptyState } from './EmptyState';

--- a/apps/web/src/pages/WorkPage/types.ts
+++ b/apps/web/src/pages/WorkPage/types.ts
@@ -1,4 +1,4 @@
-export type MainTab = 'all' | 'jobs' | 'services';
+export type MainTab = 'all' | 'jobs' | 'services' | 'mine';
 
 export interface WorkItem {
   id: string;


### PR DESCRIPTION
## What this does
Absorbs personal work management into the Work page as a fourth tab, completing the Profile → Work restructure.

Closes #74

## Changes
- Create `useMyWork` hook for task/offering/application data fetching
- Add `mine` to MainTab type
- Update TabBar with Mans pill (amber), hide filter when Mine active
- Create MyWorkDashboard component (reuses TasksTab + OfferingsTab)
- Create WorkFAB floating action button
- Update WorkPage to render Mine tab content
- Skip marketplace fetch when in Mine mode (performance)