### PR TITLE
refactor: flatten @marketplace/shared deep imports to barrel imports

### DIFF
--- a/apps/web/src/api/hooks/useMessages.ts
+++ b/apps/web/src/api/hooks/useMessages.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getConversations, getConversation, getMessages, sendMessage, markAsRead } from '@marketplace/shared/src/api/messages';
+import { getConversations, getConversation, getMessages, sendMessage, markAsRead } from '@marketplace/shared';
 
 // Query keys for cache management
 export const messageKeys = {

--- a/apps/web/src/api/hooks/useNotifications.ts
+++ b/apps/web/src/api/hooks/useNotifications.ts
@@ -1,12 +1,12 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getNotifications,
-  getUnreadCount,
-  markAsRead,
-  markAllAsRead,
+  getUnreadNotificationCount as getUnreadCount,
+  markNotificationAsRead as markAsRead,
+  markAllNotificationsAsRead as markAllAsRead,
   markReadByType,
-} from '@marketplace/shared/src/api/notifications';
-import { getUnreadCount as getMessagesUnreadCount } from '@marketplace/shared/src/api/messages';
+  getUnreadCount as getMessagesUnreadCount,
+} from '@marketplace/shared';
 
 // Query keys for cache management
 export const notificationKeys = {

--- a/apps/web/src/api/hooks/useOfferings.ts
+++ b/apps/web/src/api/hooks/useOfferings.ts
@@ -9,7 +9,7 @@ import {
   updateOffering, 
   boostOffering,
   OfferingsParams 
-} from '@marketplace/shared/src/api/offerings';
+} from '@marketplace/shared';
 
 // Query keys for cache management
 // Include language in keys that return translated content

--- a/apps/web/src/api/hooks/useTasks.ts
+++ b/apps/web/src/api/hooks/useTasks.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { getTasks, getTask, getMyTasks, createTask, updateTask, applyToTask, withdrawApplication, TasksParams, getCurrentLanguage } from '@marketplace/shared/src/api/tasks';
+import { getTasks, getTask, getMyTasks, createTask, updateTask, applyToTask, withdrawApplication, TasksParams, getCurrentLanguage } from '@marketplace/shared';
 
 // Query keys for cache management
 // Include language in keys that return translated content

--- a/apps/web/src/api/hooks/useUsers.ts
+++ b/apps/web/src/api/hooks/useUsers.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getPublicUser, getUserReviews, PublicUser, UserReview } from '@marketplace/shared/src/api/users';
-import { startConversation, Conversation } from '@marketplace/shared/src/api/messages';
+import { getPublicUser, getUserReviews, startConversation } from '@marketplace/shared';
+import type { PublicUser, UserReview, Conversation } from '@marketplace/shared';
 
 // Query keys for cache management
 export const userKeys = {

--- a/apps/web/src/pages/listings/CreateListing.tsx
+++ b/apps/web/src/pages/listings/CreateListing.tsx
@@ -2,7 +2,7 @@ import { useState, useRef } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useCreateListing } from '../../hooks/useListings'
-import { uploadImage, getImageUrl } from '@marketplace/shared/src/api/uploads'
+import { uploadImage, getImageUrl } from '@marketplace/shared'
 import ErrorMessage from '../../components/ui/ErrorMessage'
 import { CATEGORIES, LOCATIONS } from './constants'
 

--- a/apps/web/src/pages/listings/EditListing.tsx
+++ b/apps/web/src/pages/listings/EditListing.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { useAuthStore, useToastStore, listingsApi, type Listing } from '@marketplace/shared'
-import { uploadImage, getImageUrl } from '@marketplace/shared/src/api/uploads'
+import { useAuthStore, useToastStore, listingsApi, uploadImage, getImageUrl, type Listing } from '@marketplace/shared'
 import LoadingSpinner from '../../components/ui/LoadingSpinner'
 
 const CATEGORIES = [


### PR DESCRIPTION
Closed — superseded by clean rebased PR from current main.