### PR TITLE
refactor: flatten @marketplace/shared deep imports to barrel imports (v2)

### DIFF
--- a/apps/web/src/api/hooks/useMessages.ts
+++ b/apps/web/src/api/hooks/useMessages.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getConversations, getConversation, getMessages, sendMessage, markAsRead } from '@marketplace/shared/src/api/messages';
+import { getConversations, getConversation, getMessages, sendMessage, markAsRead } from '@marketplace/shared';
 
 // Query keys for cache management
 export const messageKeys = {

--- a/apps/web/src/api/hooks/useNotifications.ts
+++ b/apps/web/src/api/hooks/useNotifications.ts
@@ -1,12 +1,12 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getNotifications,
-  getUnreadCount,
-  markAsRead,
-  markAllAsRead,
+  getUnreadNotificationCount as getUnreadCount,
+  markNotificationAsRead as markAsRead,
+  markAllNotificationsAsRead as markAllAsRead,
   markReadByType,
-} from '@marketplace/shared/src/api/notifications';
-import { getUnreadCount as getMessagesUnreadCount } from '@marketplace/shared/src/api/messages';
+  getUnreadCount as getMessagesUnreadCount,
+} from '@marketplace/shared';
 
 // Query keys for cache management
 export const notificationKeys = {

--- a/apps/web/src/api/hooks/useOfferings.ts
+++ b/apps/web/src/api/hooks/useOfferings.ts
@@ -9,7 +9,7 @@ import {
   updateOffering, 
   boostOffering,
   OfferingsParams 
-} from '@marketplace/shared/src/api/offerings';
+} from '@marketplace/shared';
 
 // Query keys for cache management
 // Include language in keys that return translated content

--- a/apps/web/src/api/hooks/useTasks.ts
+++ b/apps/web/src/api/hooks/useTasks.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { getTasks, getTask, getMyTasks, createTask, updateTask, applyToTask, withdrawApplication, TasksParams, getCurrentLanguage } from '@marketplace/shared/src/api/tasks';
+import { getTasks, getTask, getMyTasks, createTask, updateTask, applyToTask, withdrawApplication, TasksParams, getCurrentLanguage } from '@marketplace/shared';
 
 // Query keys for cache management
 // Include language in keys that return translated content

--- a/apps/web/src/api/hooks/useUsers.ts
+++ b/apps/web/src/api/hooks/useUsers.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getPublicUser, getUserReviews, PublicUser, UserReview } from '@marketplace/shared/src/api/users';
-import { startConversation, Conversation } from '@marketplace/shared/src/api/messages';
+import { getPublicUser, getUserReviews, startConversation } from '@marketplace/shared';
+import type { PublicUser, UserReview, Conversation } from '@marketplace/shared';
 
 // Query keys for cache management
 export const userKeys = {


### PR DESCRIPTION
## Summary

Clean rebased version of #86 (closed due to build failure + merge conflicts).

Rewires 5 hook files from deep `@marketplace/shared/src/api/...` imports to use the `@marketplace/shared` barrel. Every imported symbol is already re-exported through the barrel — no barrel changes needed.

*Note: CreateListing.tsx and EditListing.tsx from original PR no longer exist on main.*

## What Changed

| File | Before | After |
|------|--------|-------|
| `api/hooks/useMessages.ts` | `@marketplace/shared/src/api/messages` | `@marketplace/shared` |
| `api/hooks/useNotifications.ts` | `@marketplace/shared/src/api/notifications` + `…/messages` | `@marketplace/shared` (with reverse-aliases for renamed exports) |
| `api/hooks/useOfferings.ts` | `@marketplace/shared/src/api/offerings` | `@marketplace/shared` |
| `api/hooks/useTasks.ts` | `@marketplace/shared/src/api/tasks` | `@marketplace/shared` |
| `api/hooks/useUsers.ts` | `@marketplace/shared/src/api/users` + `…/messages` | `@marketplace/shared` (merged into single import) |

## Barrel Verification

All symbols verified against `packages/shared/src/api/index.ts`:
- Messages: `export * from './messages'` ✅
- Notifications: explicitly re-exported with renamed aliases ✅
- Offerings: `export * from './offerings'` ✅
- Tasks: explicitly re-exported ✅
- Users: `export * from './users'` ✅
- Uploads: `export * from './uploads'` ✅

## Risk

**Zero** — pure import path changes. Every symbol resolves to the same function.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2FojayWillow%2Fmarketplace-frontend%2Fpull%2F91&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->