### PR TITLE
refactor: split UserProfile.tsx into sub-components

### DIFF
--- a/apps/web/src/pages/UserProfile.tsx
+++ b/apps/web/src/pages/UserProfile.tsx
@@ -1,11 +1,16 @@
 import { useState, useEffect } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore, useToastStore, apiClient } from '@marketplace/shared';
 import { useStartConversation } from '../api/hooks';
 import { usePublicProfileData } from './Profile/hooks';
 import { useQueryClient } from '@tanstack/react-query';
 import { getCategoryIcon, getCategoryLabel } from '../constants/categories';
+
+import ProfileHeader from './UserProfile/ProfileHeader';
+import WorkCard from './UserProfile/WorkCard';
+import ReviewCard from './UserProfile/ReviewCard';
+import ReviewModal from './UserProfile/ReviewModal';
 
 interface ReviewableTransaction {
   type: string;
@@ -37,10 +42,8 @@ export default function UserProfile() {
 
   const startConversationMutation = useStartConversation();
 
-  // Review modal state
+  // Review state
   const [showReviewModal, setShowReviewModal] = useState(false);
-  const [reviewData, setReviewData] = useState({ rating: 5, content: '', taskId: 0 });
-  const [submittingReview, setSubmittingReview] = useState(false);
   const [reviewableTransactions, setReviewableTransactions] = useState<ReviewableTransaction[]>([]);
   const [canReview, setCanReview] = useState(false);
 
@@ -56,9 +59,6 @@ export default function UserProfile() {
         const response = await apiClient.get(`/api/reviews/can-review-user/${id}`);
         setCanReview(response.data.can_review);
         setReviewableTransactions(response.data.reviewable_transactions || []);
-        if (response.data.reviewable_transactions?.length > 0) {
-          setReviewData(prev => ({ ...prev, taskId: response.data.reviewable_transactions[0].id }));
-        }
       } catch {
         setCanReview(false);
         setReviewableTransactions([]);
@@ -81,30 +81,21 @@ export default function UserProfile() {
     });
   };
 
-  const handleSubmitReview = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmitReview = async (data: { rating: number; content: string; taskId: number }) => {
     if (!currentUser) { toast.error('Please login to leave a review'); return; }
-    if (!reviewData.content.trim()) { toast.error('Please write a review comment'); return; }
-    if (!reviewData.taskId) { toast.error('Please select a transaction to review'); return; }
+    if (!data.content.trim()) { toast.error('Please write a review comment'); return; }
+    if (!data.taskId) { toast.error('Please select a transaction to review'); return; }
 
-    try {
-      setSubmittingReview(true);
-      await apiClient.post(`/api/reviews/task/${reviewData.taskId}`, {
-        rating: reviewData.rating,
-        content: reviewData.content,
-      });
-      queryClient.invalidateQueries({ queryKey: ['user-reviews', Number(id)] });
-      queryClient.invalidateQueries({ queryKey: ['user-profile', Number(id)] });
-      setReviewableTransactions(prev => prev.filter(t => t.id !== reviewData.taskId));
-      if (reviewableTransactions.length <= 1) setCanReview(false);
-      setShowReviewModal(false);
-      setReviewData({ rating: 5, content: '', taskId: 0 });
-      toast.success('Review submitted successfully!');
-    } catch (err: any) {
-      toast.error(err?.response?.data?.error || 'Failed to submit review');
-    } finally {
-      setSubmittingReview(false);
-    }
+    await apiClient.post(`/api/reviews/task/${data.taskId}`, {
+      rating: data.rating,
+      content: data.content,
+    });
+    queryClient.invalidateQueries({ queryKey: ['user-reviews', Number(id)] });
+    queryClient.invalidateQueries({ queryKey: ['user-profile', Number(id)] });
+    setReviewableTransactions(prev => prev.filter(t => t.id !== data.taskId));
+    if (reviewableTransactions.length <= 1) setCanReview(false);
+    setShowReviewModal(false);
+    toast.success('Review submitted successfully!');
   };
 
   /* ── Derived data ── */
@@ -143,7 +134,7 @@ export default function UserProfile() {
         <div className="text-center">
           <div className="text-5xl mb-4">😕</div>
           <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">User not found</h2>
-          <p className="text-gray-500 dark:text-gray-400 mb-6">{error || 'This profile doesn\'t exist or has been removed.'}</p>
+          <p className="text-gray-500 dark:text-gray-400 mb-6">{error || "This profile doesn't exist or has been removed."}</p>
           <button
             onClick={() => navigate(-1)}
             className="px-6 py-2.5 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-xl font-medium hover:bg-gray-800 dark:hover:bg-gray-200 transition-colors"
@@ -160,7 +151,7 @@ export default function UserProfile() {
       <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
         <div className="max-w-lg mx-auto px-4 py-6">
 
-          {/* ── Back button ── */}
+          {/* Back button */}
           <button
             onClick={() => navigate(-1)}
             className="flex items-center gap-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors mb-6 -ml-1"
@@ -171,69 +162,18 @@ export default function UserProfile() {
             <span className="text-sm font-medium">Back</span>
           </button>
 
-          {/* ═══ IDENTITY SECTION ═══ */}
-          <div className="flex flex-col items-center text-center mb-6">
-            <div className="w-24 h-24 rounded-full overflow-hidden bg-gray-200 dark:bg-gray-700 mb-4 ring-4 ring-white dark:ring-gray-800 shadow-lg">
-              {avatarUrl ? (
-                <img src={avatarUrl} alt={displayName} className="w-full h-full object-cover" />
-              ) : (
-                <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-gray-700 to-gray-900 text-white text-3xl font-bold">
-                  {initials}
-                </div>
-              )}
-            </div>
+          <ProfileHeader
+            displayName={displayName}
+            avatarUrl={avatarUrl}
+            initials={initials}
+            bio={profile.bio}
+            isVerified={profile.is_verified}
+            memberSince={memberSince}
+            averageRating={profile.average_rating}
+            reviewsCount={profile.reviews_count}
+          />
 
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-1">{displayName}</h1>
-
-            {profile.bio && (
-              <p className="text-gray-500 dark:text-gray-400 text-sm leading-relaxed max-w-xs mb-3">
-                {profile.bio}
-              </p>
-            )}
-
-            <div className="flex items-center gap-3 text-sm">
-              {profile.is_verified && (
-                <span className="inline-flex items-center gap-1 text-green-600 dark:text-green-400 font-medium">
-                  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" />
-                  </svg>
-                  Verified
-                </span>
-              )}
-              {memberSince && (
-                <span className="text-gray-400 dark:text-gray-500">
-                  Member since {memberSince}
-                </span>
-              )}
-            </div>
-
-            {(profile.average_rating != null && profile.reviews_count != null && profile.reviews_count > 0) && (
-              <div className="flex items-center gap-1.5 mt-3">
-                <div className="flex items-center">
-                  {[1, 2, 3, 4, 5].map(star => (
-                    <span
-                      key={star}
-                      className={`text-lg ${
-                        star <= Math.round(profile.average_rating || 0)
-                          ? 'text-yellow-400'
-                          : 'text-gray-200 dark:text-gray-600'
-                      }`}
-                    >
-                      ★
-                    </span>
-                  ))}
-                </div>
-                <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">
-                  {profile.average_rating?.toFixed(1)}
-                </span>
-                <span className="text-sm text-gray-400 dark:text-gray-500">
-                  ({profile.reviews_count} {profile.reviews_count === 1 ? 'review' : 'reviews'})
-                </span>
-              </div>
-            )}
-          </div>
-
-          {/* ═══ ACTION BUTTONS ═══ */}
+          {/* Action buttons */}
           <div className="flex gap-3 mb-8">
             <button
               onClick={handleMessage}
@@ -262,7 +202,7 @@ export default function UserProfile() {
             )}
           </div>
 
-          {/* ═══ REVIEW BUTTON ═══ */}
+          {/* Leave a Review */}
           {canReview && (
             <button
               onClick={() => setShowReviewModal(true)}
@@ -272,7 +212,7 @@ export default function UserProfile() {
             </button>
           )}
 
-          {/* ═══ SKILLS ═══ */}
+          {/* Skills */}
           {skills.length > 0 && (
             <div className="mb-8">
               <h2 className="text-sm font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-3">Skills</h2>
@@ -290,90 +230,48 @@ export default function UserProfile() {
             </div>
           )}
 
-          {/* ═══ WORK ═══ */}
+          {/* Work */}
           {workCount > 0 && (
             <div className="mb-8" id="user-work">
               <h2 className="text-sm font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-3">Work</h2>
               <div className="space-y-3">
                 {offerings.map(offering => (
-                  <Link
+                  <WorkCard
                     key={`offering-${offering.id}`}
-                    to={`/offerings/${offering.id}`}
-                    className="block bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-4 hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all"
-                  >
-                    <div className="flex items-start gap-3">
-                      <div className="w-10 h-10 bg-gray-50 dark:bg-gray-800 rounded-lg flex items-center justify-center text-lg flex-shrink-0">
-                        {getCategoryIcon((offering as any).category || '')}
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-semibold text-gray-900 dark:text-gray-100 line-clamp-1">{offering.title}</p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 line-clamp-1">{offering.description}</p>
-                        {(offering as any).price && (
-                          <p className="text-sm font-bold text-green-600 dark:text-green-400 mt-1">€{(offering as any).price}</p>
-                        )}
-                      </div>
-                      <span className="text-[10px] font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 px-2 py-0.5 rounded-full flex-shrink-0">
-                        Offering
-                      </span>
-                    </div>
-                  </Link>
+                    id={offering.id}
+                    type="offering"
+                    title={offering.title}
+                    description={offering.description}
+                    price={(offering as any).price}
+                    category={(offering as any).category}
+                  />
                 ))}
-
                 {tasks.map(task => (
-                  <Link
+                  <WorkCard
                     key={`task-${task.id}`}
-                    to={`/tasks/${task.id}`}
-                    className="block bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-4 hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all"
-                  >
-                    <div className="flex items-start gap-3">
-                      <div className="w-10 h-10 bg-gray-50 dark:bg-gray-800 rounded-lg flex items-center justify-center text-lg flex-shrink-0">
-                        {getCategoryIcon((task as any).category || '')}
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-semibold text-gray-900 dark:text-gray-100 line-clamp-1">{task.title}</p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 line-clamp-1">{task.description}</p>
-                        {task.budget && (
-                          <p className="text-sm font-bold text-green-600 dark:text-green-400 mt-1">€{task.budget}</p>
-                        )}
-                      </div>
-                      <span className="text-[10px] font-medium text-orange-600 dark:text-orange-400 bg-orange-50 dark:bg-orange-900/20 px-2 py-0.5 rounded-full flex-shrink-0">
-                        Task
-                      </span>
-                    </div>
-                  </Link>
+                    id={task.id}
+                    type="task"
+                    title={task.title}
+                    description={task.description}
+                    price={task.budget}
+                    category={(task as any).category}
+                  />
                 ))}
-
                 {listings.map(listing => (
-                  <Link
+                  <WorkCard
                     key={`listing-${listing.id}`}
-                    to={`/listings/${listing.id}`}
-                    className="block bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-4 hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all"
-                  >
-                    <div className="flex items-start gap-3">
-                      <div className="w-10 h-10 bg-gray-100 dark:bg-gray-800 rounded-lg overflow-hidden flex-shrink-0">
-                        {(listing as any).images?.[0] ? (
-                          <img src={(listing as any).images[0]} alt="" className="w-full h-full object-cover" />
-                        ) : (
-                          <div className="w-full h-full flex items-center justify-center text-lg">📋</div>
-                        )}
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-semibold text-gray-900 dark:text-gray-100 line-clamp-1">{listing.title}</p>
-                        {(listing as any).price && (
-                          <p className="text-sm font-bold text-green-600 dark:text-green-400 mt-1">€{(listing as any).price}</p>
-                        )}
-                      </div>
-                      <span className="text-[10px] font-medium text-purple-600 dark:text-purple-400 bg-purple-50 dark:bg-purple-900/20 px-2 py-0.5 rounded-full flex-shrink-0">
-                        Listing
-                      </span>
-                    </div>
-                  </Link>
+                    id={listing.id}
+                    type="listing"
+                    title={listing.title}
+                    price={(listing as any).price}
+                    image={(listing as any).images?.[0]}
+                  />
                 ))}
               </div>
             </div>
           )}
 
-          {/* ═══ REVIEWS ═══ */}
+          {/* Reviews */}
           {reviews.length > 0 && (
             <div className="mb-8">
               <h2 className="text-sm font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-3">
@@ -381,56 +279,7 @@ export default function UserProfile() {
               </h2>
               <div className="space-y-3">
                 {reviews.map(review => (
-                  <div
-                    key={review.id}
-                    className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-4"
-                  >
-                    <div className="flex items-start gap-3">
-                      <div className="w-9 h-9 rounded-full overflow-hidden bg-gray-200 dark:bg-gray-700 flex-shrink-0">
-                        {review.reviewer_avatar ? (
-                          <img src={review.reviewer_avatar} alt={review.reviewer_name} className="w-full h-full object-cover" />
-                        ) : (
-                          <div className="w-full h-full flex items-center justify-center bg-gray-300 dark:bg-gray-600 text-white text-sm font-bold">
-                            {(review.reviewer_name?.[0] || '?').toUpperCase()}
-                          </div>
-                        )}
-                      </div>
-
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center justify-between mb-1">
-                          <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-                            {review.reviewer_name}
-                          </span>
-                          <span className="text-xs text-gray-400 dark:text-gray-500">
-                            {new Date(review.created_at).toLocaleDateString(undefined, {
-                              month: 'short',
-                              day: 'numeric',
-                              year: 'numeric',
-                            })}
-                          </span>
-                        </div>
-
-                        <div className="flex items-center gap-0.5 mb-2">
-                          {[1, 2, 3, 4, 5].map(star => (
-                            <span
-                              key={star}
-                              className={`text-sm ${
-                                star <= review.rating ? 'text-yellow-400' : 'text-gray-200 dark:text-gray-600'
-                              }`}
-                            >
-                              ★
-                            </span>
-                          ))}
-                        </div>
-
-                        {review.content && (
-                          <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
-                            {review.content}
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                  </div>
+                  <ReviewCard key={review.id} review={review} />
                 ))}
               </div>
             </div>
@@ -448,105 +297,14 @@ export default function UserProfile() {
         </div>
       </div>
 
-      {/* ═══ REVIEW MODAL ═══ */}
+      {/* Review Modal */}
       {showReviewModal && (
-        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-end md:items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-900 w-full max-w-md rounded-t-2xl md:rounded-2xl p-6 animate-in slide-in-from-bottom">
-            <div className="flex items-center justify-between mb-5">
-              <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100">
-                Review {displayName}
-              </h3>
-              <button
-                onClick={() => {
-                  setShowReviewModal(false);
-                  setReviewData({ rating: 5, content: '', taskId: reviewableTransactions[0]?.id || 0 });
-                }}
-                className="w-8 h-8 flex items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700"
-              >
-                <svg className="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-
-            <form onSubmit={handleSubmitReview}>
-              {reviewableTransactions.length > 1 && (
-                <div className="mb-4">
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Transaction</label>
-                  <select
-                    value={reviewData.taskId}
-                    onChange={(e) => setReviewData(prev => ({ ...prev, taskId: Number(e.target.value) }))}
-                    className="w-full px-4 py-2.5 border border-gray-200 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-gray-900 dark:focus:ring-gray-100 focus:border-transparent text-sm"
-                  >
-                    {reviewableTransactions.map(tx => (
-                      <option key={tx.id} value={tx.id}>
-                        {tx.title} ({tx.your_role})
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              )}
-
-              {reviewableTransactions.length === 1 && (
-                <div className="mb-4 p-3 bg-gray-50 dark:bg-gray-800 rounded-xl">
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    For: <span className="font-medium text-gray-900 dark:text-gray-200">{reviewableTransactions[0].title}</span>
-                  </p>
-                </div>
-              )}
-
-              <div className="mb-4">
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Rating</label>
-                <div className="flex justify-center gap-1">
-                  {[1, 2, 3, 4, 5].map(star => (
-                    <button
-                      key={star}
-                      type="button"
-                      onClick={() => setReviewData(prev => ({ ...prev, rating: star }))}
-                      className={`text-4xl transition-all hover:scale-110 ${
-                        star <= reviewData.rating ? 'text-yellow-400' : 'text-gray-200 dark:text-gray-600'
-                      }`}
-                    >
-                      ★
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              <div className="mb-6">
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Your review</label>
-                <textarea
-                  value={reviewData.content}
-                  onChange={(e) => setReviewData(prev => ({ ...prev, content: e.target.value }))}
-                  rows={4}
-                  className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-gray-900 dark:focus:ring-gray-100 focus:border-transparent text-sm resize-none placeholder:text-gray-400 dark:placeholder:text-gray-500"
-                  placeholder="Share your experience…"
-                  required
-                />
-              </div>
-
-              <div className="flex gap-3">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setShowReviewModal(false);
-                    setReviewData({ rating: 5, content: '', taskId: reviewableTransactions[0]?.id || 0 });
-                  }}
-                  className="flex-1 py-3 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded-xl font-medium hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={submittingReview}
-                  className="flex-1 py-3 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-xl font-medium hover:bg-gray-800 dark:hover:bg-gray-200 transition-colors disabled:opacity-50"
-                >
-                  {submittingReview ? 'Submitting…' : 'Submit'}
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
+        <ReviewModal
+          displayName={displayName}
+          reviewableTransactions={reviewableTransactions}
+          onSubmit={handleSubmitReview}
+          onClose={() => setShowReviewModal(false)}
+        />
       )}
     </>
   );

--- a/apps/web/src/pages/UserProfile/ProfileHeader.tsx
+++ b/apps/web/src/pages/UserProfile/ProfileHeader.tsx
@@ -1,0 +1,84 @@
+interface ProfileHeaderProps {
+  displayName: string;
+  avatarUrl?: string;
+  initials: string;
+  bio?: string;
+  isVerified?: boolean;
+  memberSince: string;
+  averageRating?: number | null;
+  reviewsCount?: number | null;
+}
+
+export default function ProfileHeader({
+  displayName,
+  avatarUrl,
+  initials,
+  bio,
+  isVerified,
+  memberSince,
+  averageRating,
+  reviewsCount,
+}: ProfileHeaderProps) {
+  return (
+    <div className="flex flex-col items-center text-center mb-6">
+      <div className="w-24 h-24 rounded-full overflow-hidden bg-gray-200 dark:bg-gray-700 mb-4 ring-4 ring-white dark:ring-gray-800 shadow-lg">
+        {avatarUrl ? (
+          <img src={avatarUrl} alt={displayName} className="w-full h-full object-cover" />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-gray-700 to-gray-900 text-white text-3xl font-bold">
+            {initials}
+          </div>
+        )}
+      </div>
+
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-1">{displayName}</h1>
+
+      {bio && (
+        <p className="text-gray-500 dark:text-gray-400 text-sm leading-relaxed max-w-xs mb-3">
+          {bio}
+        </p>
+      )}
+
+      <div className="flex items-center gap-3 text-sm">
+        {isVerified && (
+          <span className="inline-flex items-center gap-1 text-green-600 dark:text-green-400 font-medium">
+            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" />
+            </svg>
+            Verified
+          </span>
+        )}
+        {memberSince && (
+          <span className="text-gray-400 dark:text-gray-500">
+            Member since {memberSince}
+          </span>
+        )}
+      </div>
+
+      {(averageRating != null && reviewsCount != null && reviewsCount > 0) && (
+        <div className="flex items-center gap-1.5 mt-3">
+          <div className="flex items-center">
+            {[1, 2, 3, 4, 5].map(star => (
+              <span
+                key={star}
+                className={`text-lg ${
+                  star <= Math.round(averageRating || 0)
+                    ? 'text-yellow-400'
+                    : 'text-gray-200 dark:text-gray-600'
+                }`}
+              >
+                ★
+              </span>
+            ))}
+          </div>
+          <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+            {averageRating?.toFixed(1)}
+          </span>
+          <span className="text-sm text-gray-400 dark:text-gray-500">
+            ({reviewsCount} {reviewsCount === 1 ? 'review' : 'reviews'})
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/UserProfile/ReviewCard.tsx
+++ b/apps/web/src/pages/UserProfile/ReviewCard.tsx
@@ -1,0 +1,62 @@
+interface ReviewCardProps {
+  review: {
+    id: number;
+    reviewer_name: string;
+    reviewer_avatar?: string;
+    rating: number;
+    content?: string;
+    created_at: string;
+  };
+}
+
+export default function ReviewCard({ review }: ReviewCardProps) {
+  return (
+    <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-4">
+      <div className="flex items-start gap-3">
+        <div className="w-9 h-9 rounded-full overflow-hidden bg-gray-200 dark:bg-gray-700 flex-shrink-0">
+          {review.reviewer_avatar ? (
+            <img src={review.reviewer_avatar} alt={review.reviewer_name} className="w-full h-full object-cover" />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center bg-gray-300 dark:bg-gray-600 text-white text-sm font-bold">
+              {(review.reviewer_name?.[0] || '?').toUpperCase()}
+            </div>
+          )}
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              {review.reviewer_name}
+            </span>
+            <span className="text-xs text-gray-400 dark:text-gray-500">
+              {new Date(review.created_at).toLocaleDateString(undefined, {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+              })}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-0.5 mb-2">
+            {[1, 2, 3, 4, 5].map(star => (
+              <span
+                key={star}
+                className={`text-sm ${
+                  star <= review.rating ? 'text-yellow-400' : 'text-gray-200 dark:text-gray-600'
+                }`}
+              >
+                ★
+              </span>
+            ))}
+          </div>
+
+          {review.content && (
+            <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+              {review.content}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/UserProfile/ReviewModal.tsx
+++ b/apps/web/src/pages/UserProfile/ReviewModal.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+
+interface ReviewableTransaction {
+  type: string;
+  id: number;
+  title: string;
+  completed_at: string | null;
+  your_role: string;
+  review_type: string;
+}
+
+interface ReviewModalProps {
+  displayName: string;
+  reviewableTransactions: ReviewableTransaction[];
+  onSubmit: (data: { rating: number; content: string; taskId: number }) => Promise<void>;
+  onClose: () => void;
+}
+
+export default function ReviewModal({ displayName, reviewableTransactions, onSubmit, onClose }: ReviewModalProps) {
+  const [rating, setRating] = useState(5);
+  const [content, setContent] = useState('');
+  const [taskId, setTaskId] = useState(reviewableTransactions[0]?.id || 0);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      await onSubmit({ rating, content, taskId });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-end md:items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-900 w-full max-w-md rounded-t-2xl md:rounded-2xl p-6 animate-in slide-in-from-bottom">
+        <div className="flex items-center justify-between mb-5">
+          <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100">
+            Review {displayName}
+          </h3>
+          <button
+            onClick={onClose}
+            className="w-8 h-8 flex items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700"
+          >
+            <svg className="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          {reviewableTransactions.length > 1 && (
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Transaction</label>
+              <select
+                value={taskId}
+                onChange={(e) => setTaskId(Number(e.target.value))}
+                className="w-full px-4 py-2.5 border border-gray-200 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-gray-900 dark:focus:ring-gray-100 focus:border-transparent text-sm"
+              >
+                {reviewableTransactions.map(tx => (
+                  <option key={tx.id} value={tx.id}>
+                    {tx.title} ({tx.your_role})
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {reviewableTransactions.length === 1 && (
+            <div className="mb-4 p-3 bg-gray-50 dark:bg-gray-800 rounded-xl">
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                For: <span className="font-medium text-gray-900 dark:text-gray-200">{reviewableTransactions[0].title}</span>
+              </p>
+            </div>
+          )}
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Rating</label>
+            <div className="flex justify-center gap-1">
+              {[1, 2, 3, 4, 5].map(star => (
+                <button
+                  key={star}
+                  type="button"
+                  onClick={() => setRating(star)}
+                  className={`text-4xl transition-all hover:scale-110 ${
+                    star <= rating ? 'text-yellow-400' : 'text-gray-200 dark:text-gray-600'
+                  }`}
+                >
+                  ★
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="mb-6">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Your review</label>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              rows={4}
+              className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-gray-900 dark:focus:ring-gray-100 focus:border-transparent text-sm resize-none placeholder:text-gray-400 dark:placeholder:text-gray-500"
+              placeholder="Share your experience…"
+              required
+            />
+          </div>
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 py-3 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded-xl font-medium hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex-1 py-3 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-xl font-medium hover:bg-gray-800 dark:hover:bg-gray-200 transition-colors disabled:opacity-50"
+            >
+              {submitting ? 'Submitting…' : 'Submit'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/UserProfile/WorkCard.tsx
+++ b/apps/web/src/pages/UserProfile/WorkCard.tsx
@@ -1,0 +1,57 @@
+import { Link } from 'react-router-dom';
+import { getCategoryIcon } from '../../constants/categories';
+
+interface WorkCardProps {
+  id: number;
+  type: 'offering' | 'task' | 'listing';
+  title: string;
+  description?: string;
+  price?: number;
+  category?: string;
+  image?: string;
+}
+
+const badgeConfig = {
+  offering: { label: 'Offering', text: 'text-blue-600 dark:text-blue-400', bg: 'bg-blue-50 dark:bg-blue-900/20' },
+  task:     { label: 'Task',     text: 'text-orange-600 dark:text-orange-400', bg: 'bg-orange-50 dark:bg-orange-900/20' },
+  listing:  { label: 'Listing',  text: 'text-purple-600 dark:text-purple-400', bg: 'bg-purple-50 dark:bg-purple-900/20' },
+} as const;
+
+const routePrefix = { offering: '/offerings', task: '/tasks', listing: '/listings' } as const;
+
+export default function WorkCard({ id, type, title, description, price, category, image }: WorkCardProps) {
+  const badge = badgeConfig[type];
+
+  const icon = type === 'listing' && image ? (
+    <img src={image} alt="" className="w-full h-full object-cover" />
+  ) : type === 'listing' ? (
+    <div className="w-full h-full flex items-center justify-center text-lg">📋</div>
+  ) : (
+    <>{getCategoryIcon(category || '')}</>
+  );
+
+  return (
+    <Link
+      to={`${routePrefix[type]}/${id}`}
+      className="block bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-4 hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all"
+    >
+      <div className="flex items-start gap-3">
+        <div className={`w-10 h-10 rounded-lg flex items-center justify-center text-lg flex-shrink-0 ${type === 'listing' ? 'bg-gray-100 dark:bg-gray-800 overflow-hidden' : 'bg-gray-50 dark:bg-gray-800'}`}>
+          {icon}
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-gray-900 dark:text-gray-100 line-clamp-1">{title}</p>
+          {description && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 line-clamp-1">{description}</p>
+          )}
+          {price != null && price > 0 && (
+            <p className="text-sm font-bold text-green-600 dark:text-green-400 mt-1">€{price}</p>
+          )}
+        </div>
+        <span className={`text-[10px] font-medium ${badge.text} ${badge.bg} px-2 py-0.5 rounded-full flex-shrink-0`}>
+          {badge.label}
+        </span>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
## What

Breaks down `UserProfile.tsx` (26.7KB, ~700 lines) into 4 focused sub-components:

| New file | Responsibility | Size |
|---|---|---|
| `UserProfile/ProfileHeader.tsx` | Avatar, name, bio, verified badge, member since, star rating | ~95 lines |
| `UserProfile/WorkCard.tsx` | Unified work item card (replaces 3 copy-pasted loops for offerings, tasks, listings) | ~60 lines |
| `UserProfile/ReviewCard.tsx` | Single review display with avatar, stars, content | ~55 lines |
| `UserProfile/ReviewModal.tsx` | Review form — rating selector, transaction picker, textarea, submit | ~130 lines |

## Why

- **Parent file cut by 53%** — from 26.7KB to 12.5KB
- **DRY fix** — the three work card loops (offerings, tasks, listings) were near-identical copy-paste with only the route prefix, price field name, and badge color differing. Now it's one `WorkCard` component with a `type` prop.
- **Isolation** — `ReviewModal` owns its own form state (`rating`, `content`, `taskId`, `submitting`) instead of leaking 4 `useState` calls into the parent.
- **Testability** — each component can be tested/storybooked independently.

## What didn't change

- Zero behavioral changes — pixel-identical output
- Same API calls, same routes, same handlers
- No new dependencies
- `Link` import removed from parent (moved to `WorkCard`), all other imports unchanged

## Part of

Phase 3 (Giant Component Breakdown) from audit issue #82.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/95?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->