### PR TITLE
refactor: consolidate duplicated categories into shared re-exports

### DIFF
--- a/apps/web/src/constants/categories.ts
+++ b/apps/web/src/constants/categories.ts
@@ -1,7 +1,19 @@
-// Unified categories for Jobs and Offerings
-// Aligned with shared package - same categories across web and mobile
-// Designed for quick-help gig platform - simple, clear categories
+// Re-export categories from shared package — single source of truth.
+// This adapter maps shared's `.key` field to `.value` so existing
+// web consumers don't need any changes.
 
+import {
+  CATEGORIES as SHARED_CATEGORIES,
+  FORM_CATEGORIES,
+  getCategoryByKey,
+  getCategoryIcon,
+  getCategoryLabel,
+  getCategoryDescription,
+  LEGACY_CATEGORY_MAP,
+  normalizeCategory,
+} from '@marketplace/shared';
+
+// Re-export types with web's `.value` field alias
 export interface Category {
   value: string;
   label: string;
@@ -9,52 +21,32 @@ export interface Category {
   description: string;
 }
 
-// Complete category list (15 categories)
-export const CATEGORIES: Category[] = [
-  { value: 'cleaning', label: 'Cleaning', icon: '🧹', description: 'House cleaning, deep cleaning, organizing' },
-  { value: 'moving', label: 'Moving & Lifting', icon: '📦', description: 'Moving, heavy lifting, transporting' },
-  { value: 'assembly', label: 'Assembly', icon: '🔧', description: 'Furniture assembly, IKEA, mounting' },
-  { value: 'handyman', label: 'Handyman', icon: '🛠️', description: 'Repairs, fixes, small construction' },
-  { value: 'plumbing', label: 'Plumbing', icon: '🚿', description: 'Pipes, faucets, drains' },
-  { value: 'electrical', label: 'Electrical', icon: '⚡', description: 'Wiring, lighting, outlets' },
-  { value: 'painting', label: 'Painting', icon: '🎨', description: 'Wall painting, touch-ups, decorating' },
-  { value: 'outdoor', label: 'Outdoor', icon: '🌿', description: 'Gardening, yard work, snow removal' },
-  { value: 'delivery', label: 'Delivery & Errands', icon: '🚚', description: 'Delivery, shopping, errands' },
-  { value: 'care', label: 'Care', icon: '🤝', description: 'Pet care, childcare, elderly care' },
-  { value: 'tutoring', label: 'Tutoring', icon: '📚', description: 'Teaching, lessons, homework help' },
-  { value: 'tech', label: 'Tech Help', icon: '💻', description: 'Computer, phone, tech support' },
-  { value: 'beauty', label: 'Beauty', icon: '💇', description: 'Hair, makeup, styling' },
-  { value: 'events', label: 'Events', icon: '🎉', description: 'Party setup, catering, entertainment' },
-  { value: 'other', label: 'Other', icon: '📋', description: 'Everything else' },
-];
+// Map shared categories (key → value) for web consumers
+export const CATEGORIES: Category[] = FORM_CATEGORIES.map(c => ({
+  value: c.key,
+  label: c.label,
+  icon: c.icon,
+  description: c.description,
+}));
 
-// For dropdown menus - includes "All" option
+// For dropdown menus — includes "All" option
 export const CATEGORY_OPTIONS = [
   { value: 'all', label: 'All Categories', icon: '🔍' },
   ...CATEGORIES.map(c => ({ value: c.value, label: c.label, icon: c.icon }))
 ];
 
-// Quick lookup by value
+// Quick lookup by value (delegates to shared's getCategoryByKey)
 export const getCategoryByValue = (value: string): Category | undefined => {
-  return CATEGORIES.find(c => c.value === value);
+  const found = getCategoryByKey(value);
+  if (!found) return undefined;
+  return { value: found.key, label: found.label, icon: found.icon, description: found.description };
 };
 
-// Get icon for a category
-export const getCategoryIcon = (value: string): string => {
-  return getCategoryByValue(value)?.icon || '📋';
-};
+// Re-export helpers directly — they work with string keys, no mapping needed
+export { getCategoryIcon, getCategoryLabel, getCategoryDescription };
+export { LEGACY_CATEGORY_MAP, normalizeCategory };
 
-// Get label for a category
-export const getCategoryLabel = (value: string): string => {
-  return getCategoryByValue(value)?.label || value;
-};
-
-// Get description for a category
-export const getCategoryDescription = (value: string): string => {
-  return getCategoryByValue(value)?.description || '';
-};
-
-// Group categories for organized display
+// Group categories for organized display (web-specific grouping)
 export const CATEGORY_GROUPS = [
   {
     name: 'Home & Property',
@@ -73,32 +65,3 @@ export const CATEGORY_GROUPS = [
     categories: ['other']
   }
 ];
-
-// Legacy mapping - maps old category keys to new ones
-// Use this for backward compatibility with existing data
-export const LEGACY_CATEGORY_MAP: Record<string, string> = {
-  'heavy-lifting': 'moving',
-  'mounting': 'assembly',
-  'construction': 'handyman',
-  'repair': 'handyman',
-  'gardening': 'outdoor',
-  'car-wash': 'outdoor',
-  'snow-removal': 'outdoor',
-  'pet-care': 'care',
-  'babysitting': 'care',
-  'childcare': 'care',
-  'elderly-care': 'care',
-  'shopping': 'delivery',
-  'errands': 'delivery',
-  'tech-help': 'tech',
-  'hospitality': 'events',
-  'music': 'events',
-  'photography': 'other',
-  'translation': 'other',
-  'fitness': 'other',
-};
-
-// Normalize category - converts legacy keys to new ones
-export const normalizeCategory = (value: string): string => {
-  return LEGACY_CATEGORY_MAP[value] || value;
-};


### PR DESCRIPTION
## What

`apps/web/src/constants/categories.ts` was a **full 100-line copy** of `packages/shared/src/constants/categories.ts` — same 15 categories, same icons, same helper functions, same legacy map. The only difference was field naming (`.value` vs `.key`).

This creates a drift risk: if a category is added/changed in shared (e.g. for mobile), the web copy gets out of sync silently.

## Fix

Replaced the duplicate with a **thin re-export wrapper** (~60 lines) that:
- Imports `FORM_CATEGORIES`, `getCategoryByKey`, `getCategoryIcon`, `getCategoryLabel`, etc. from `@marketplace/shared`
- Maps `.key` → `.value` so all 30 web consumer files need **zero changes**
- Keeps web-specific exports (`CATEGORY_OPTIONS`, `CATEGORY_GROUPS`) in the wrapper
- Single source of truth is now `@marketplace/shared`

## Impact

- **1 file changed** — `apps/web/src/constants/categories.ts`
- **0 consumer files changed** — all 30 files that import from this path continue to work
- **Build verified** — `npm run build` passes clean (2186 modules, 0 errors)

## Files that depend on this (verified working)

FilterSheet, JobPreviewCard, useTasksData, AdminJobs, AdminOfferings, CategoryPicker (×2), FormTips (×2), TitleInput, EditOffering, MapHomePage, MatchingJobsSection, OfferingDetail/utils, MobileFavoritesSection, OfferingsTab, TasksTab, RecommendedHelpers, TaskHeader, TaskDetail, MatchingJobsBanner, JobMapPopup, OfferingMapPopup, OfferingCard, TaskCard, useTaskData, markerIcons, Tasks, useWorkPage, UserProfile, locations.ts

Related to Phase 5e of audit issue #82.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/99?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->