### PR TITLE
refactor: prod-safe console log strategy for useSocket (#82)

### DIFF
--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -110,12 +110,12 @@ function setupSocket(token: string, socketUrl: string) {
 
   // ─── Connection events ──────────────────────────────────
   socket.on('connect', () => {
-    console.log('[Socket] ✅ Connected:', socket.id);
+    console.debug('[Socket] Connected:', socket.id);
     useSocketStore.getState().setConnected(true);
   });
 
   socket.on('disconnect', (reason) => {
-    console.log('[Socket] ❌ Disconnected:', reason);
+    console.warn('[Socket] Disconnected:', reason);
     useSocketStore.getState().setConnected(false);
   });
 


### PR DESCRIPTION
## What

Applies the agreed console log strategy to `useSocket.ts` — the only file in `apps/web/src/` still using `console.log` for socket events.

## Changes

| Before | After | Why |
|--------|-------|-----|
| `console.log('[Socket] ✅ Connected:', socket.id)` | `console.debug('[Socket] Connected:', socket.id)` | Routine success = dev-only noise |
| `console.log('[Socket] ❌ Disconnected:', reason)` | `console.warn('[Socket] Disconnected:', reason)` | Disconnects are actionable signals |
| `console.warn('[Socket] Connection error:', ...)` | _unchanged_ | Already correct |

## Strategy

| Level | When it fires | Survives prod? |
|-------|--------------|----------------|
| `console.debug` | Verbose flow tracing (connected, cleanup, socket updates) | ❌ Dev only |
| `console.warn` | Something unexpected but recoverable (disconnect, connection error) | ✅ Always |
| `console.error` | Something broke | ✅ Always |

Also removed emoji from log messages — cleaner for log aggregation and grep.

Part of #82 (Phase 3 — useSocket.ts audit)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/100?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->