### PR TITLE
fix: web app broken star ratings – proper fractional rendering

### DIFF
--- a/apps/web/src/components/MobileTasksView/components/JobPreviewCard.tsx
+++ b/apps/web/src/components/MobileTasksView/components/JobPreviewCard.tsx
@@ -6,6 +6,7 @@ import { formatTimeAgo } from '../utils/formatting';
 import { getCategoryIcon, getCategoryLabel } from '../../../constants/categories';
 import shareTask from '../../../utils/shareTask';
 import { FEATURES } from '../../../constants/featureFlags';
+import StarRating from '../../ui/StarRating';
 
 /**
  * Strip common "urgent" prefixes users may have manually typed in titles.
@@ -70,23 +71,6 @@ const JobPreviewCard = ({
       setShareState('copied');
       setTimeout(() => setShareState('idle'), 2000);
     }
-  };
-
-  const renderStars = (rating: number) => {
-    const stars = [];
-    const fullStars = Math.floor(rating);
-    const hasHalfStar = rating % 1 >= 0.5;
-    
-    for (let i = 0; i < 5; i++) {
-      if (i < fullStars) {
-        stars.push(<span key={i} className="text-yellow-400">★</span>);
-      } else if (i === fullStars && hasHalfStar) {
-        stars.push(<span key={i} className="text-yellow-400">⯨</span>);
-      } else {
-        stars.push(<span key={i} className="text-gray-300 dark:text-gray-600">★</span>);
-      }
-    }
-    return stars;
   };
 
   return (
@@ -224,14 +208,12 @@ const JobPreviewCard = ({
             )}
             
             {hasRating && (
-              <div className="flex items-center gap-1 flex-shrink-0">
-                <div className="flex text-xs">
-                  {renderStars(task.creator_rating!)}
-                </div>
-                <span className="text-xs text-gray-500 dark:text-gray-400">
-                  ({task.creator_review_count || 0})
-                </span>
-              </div>
+              <StarRating
+                rating={task.creator_rating!}
+                size="xs"
+                reviewCount={task.creator_review_count || 0}
+                showCount
+              />
             )}
             
             {hasRating && task.creator_city && (

--- a/apps/web/src/components/MobileTasksView/components/MobileJobCard.tsx
+++ b/apps/web/src/components/MobileTasksView/components/MobileJobCard.tsx
@@ -2,6 +2,7 @@ import { Task } from '@marketplace/shared';
 import { calculateDistance, formatDistance } from '../utils/distance';
 import { formatTimeAgo } from '../utils/formatting';
 import { FEATURES } from '../../../constants/featureFlags';
+import StarRating from '../../ui/StarRating';
 
 /**
  * Strip common "urgent" prefixes users may have manually typed in titles.
@@ -41,24 +42,6 @@ const MobileJobCard = ({
   const hasRating = task.creator_rating != null;
   const isUrgent = FEATURES.URGENT && task.is_urgent;
   const displayTitle = isUrgent ? cleanTitle(task.title) : task.title;
-
-  // Render star rating
-  const renderStars = (rating: number) => {
-    const stars = [];
-    const fullStars = Math.floor(rating);
-    const hasHalfStar = rating % 1 >= 0.5;
-    
-    for (let i = 0; i < 5; i++) {
-      if (i < fullStars) {
-        stars.push(<span key={i} className="text-yellow-400">★</span>);
-      } else if (i === fullStars && hasHalfStar) {
-        stars.push(<span key={i} className="text-yellow-400">⯪</span>);
-      } else {
-        stars.push(<span key={i} className="text-gray-300 dark:text-gray-600">★</span>);
-      }
-    }
-    return stars;
-  };
 
   return (
     <div
@@ -126,16 +109,14 @@ const MobileJobCard = ({
             <span className="text-gray-300 dark:text-gray-600 flex-shrink-0">|</span>
           )}
           
-          {/* Rating with stars */}
+          {/* Rating with proper fractional stars */}
           {hasRating && (
-            <div className="flex items-center gap-0.5 flex-shrink-0">
-              <div className="flex text-[10px]">
-                {renderStars(task.creator_rating!)}
-              </div>
-              <span className="text-[10px] text-gray-500 dark:text-gray-400">
-                ({task.creator_review_count || 0})
-              </span>
-            </div>
+            <StarRating
+              rating={task.creator_rating!}
+              size="xs"
+              reviewCount={task.creator_review_count || 0}
+              showCount
+            />
           )}
           
           {/* Separator before city */}

--- a/apps/web/src/components/ui/StarRating.tsx
+++ b/apps/web/src/components/ui/StarRating.tsx
@@ -4,25 +4,24 @@ interface StarRatingProps {
   /** Rating value from 0 to 5 */
   rating: number;
   /** Size of the stars */
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
   /** Additional CSS classes */
   className?: string;
   /** Whether to show the numeric rating value */
   showValue?: boolean;
   /** Number of reviews (optional, displayed in parentheses) */
   reviewCount?: number;
+  /** Whether to show the review count */
+  showCount?: boolean;
 }
 
 /**
- * Renders a star rating display with full, half, and empty stars.
- * 
+ * Renders a star rating display with precise fractional fill using CSS clip-path.
+ * For example, a 3.7 rating shows 3 full stars + 1 star filled 70% + 1 empty star.
+ *
  * @example
- * // Basic usage
- * <StarRating rating={4.5} />
- * 
- * @example
- * // With review count
- * <StarRating rating={4.5} showValue reviewCount={42} />
+ * <StarRating rating={3.7} />
+ * <StarRating rating={4.5} size="lg" showValue reviewCount={42} />
  */
 const StarRating: React.FC<StarRatingProps> = ({
   rating,
@@ -30,31 +29,64 @@ const StarRating: React.FC<StarRatingProps> = ({
   className = '',
   showValue = false,
   reviewCount,
+  showCount = false,
 }) => {
-  // Clamp rating between 0 and 5
   const clampedRating = Math.max(0, Math.min(5, rating));
-  
-  const fullStars = Math.floor(clampedRating);
-  const hasHalfStar = clampedRating % 1 >= 0.5;
-  const emptyStars = 5 - fullStars - (hasHalfStar ? 1 : 0);
 
-  const sizeClasses = {
+  const sizeClasses: Record<string, string> = {
+    xs: 'text-[10px]',
     sm: 'text-sm',
     md: 'text-lg',
     lg: 'text-2xl',
   };
 
+  const stars = [];
+  for (let i = 0; i < 5; i++) {
+    const fill = Math.max(0, Math.min(1, clampedRating - i));
+
+    if (fill >= 1) {
+      // Full star
+      stars.push(
+        <span key={i} className="text-yellow-400">
+          ★
+        </span>
+      );
+    } else if (fill > 0) {
+      // Fractional star — overlay a clipped filled star on top of an empty star
+      const percentage = Math.round(fill * 100);
+      stars.push(
+        <span key={i} className="relative inline-block">
+          <span className="text-gray-300 dark:text-gray-600">★</span>
+          <span
+            className="absolute inset-0 text-yellow-400 overflow-hidden"
+            style={{ clipPath: `inset(0 ${100 - percentage}% 0 0)` }}
+          >
+            ★
+          </span>
+        </span>
+      );
+    } else {
+      // Empty star
+      stars.push(
+        <span key={i} className="text-gray-300 dark:text-gray-600">
+          ★
+        </span>
+      );
+    }
+  }
+
   return (
     <span className={`inline-flex items-center gap-1 ${className}`}>
-      <span className={`text-yellow-500 ${sizeClasses[size]}`}>
-        {'★'.repeat(fullStars)}
-        {hasHalfStar && '½'}
-        {'☆'.repeat(emptyStars)}
-      </span>
+      <span className={`inline-flex ${sizeClasses[size]}`}>{stars}</span>
       {showValue && (
         <span className="text-gray-500 text-sm">
           {clampedRating.toFixed(1)}
           {reviewCount !== undefined && ` (${reviewCount} reviews)`}
+        </span>
+      )}
+      {showCount && !showValue && reviewCount !== undefined && (
+        <span className="text-gray-500 dark:text-gray-400" style={{ fontSize: 'inherit' }}>
+          ({reviewCount})
         </span>
       )}
     </span>


### PR DESCRIPTION
## Problem

The **web app** (`apps/web`) at kolab.lv has broken star rating rendering in the home screen slide-up bottom sheet. Two components (`MobileJobCard` and `JobPreviewCard`) each had their own inline `renderStars()` function that:

1. Used `Math.floor()` + a `>= 0.5` half-star check — meaning a 3.7 rating showed as 3.5 (losing 0.2 precision)
2. Used Unicode half-star characters (`⯪`, `⯨`) that **don't render on many browsers/devices**, showing as ugly broken glyphs
3. Had no fractional rendering — only full or "half" stars

The previous star rating fix (PR #29) only fixed `apps/mobile/components/StarRating.tsx` — the React Native mobile app. The web app at `apps/web/src` has **completely separate components** that were never touched.

## Solution

### 1. Rewrote `apps/web/src/components/ui/StarRating.tsx`
- Uses **CSS `clip-path`** for pixel-perfect fractional rendering
- A 3.7 rating now shows exactly 3 full stars + 1 star filled 70% + 1 empty star
- No Unicode half-star characters — just the standard `★` character with CSS clipping
- Added `xs` size option for compact card use
- Added `showCount` prop for displaying review count inline

### 2. Updated `MobileJobCard.tsx`
- Removed the broken inline `renderStars()` function
- Now imports and uses the shared `StarRating` component

### 3. Updated `JobPreviewCard.tsx`
- Same fix — removed inline `renderStars()`, uses shared `StarRating`

## What it looks like

| Rating | Before | After |
|--------|--------|-------|
| 3.7 | `★★★⯪☆` (broken glyph) | `★★★` + 70%-filled `★` + empty `★` |
| 4.2 | `★★★★☆` (rounded to 4) | `★★★★` + 20%-filled `★` |
| 5.0 | `★★★★★` | `★★★★★` (unchanged) |

## Files Changed
- `apps/web/src/components/ui/StarRating.tsx` — rewritten
- `apps/web/src/components/MobileTasksView/components/MobileJobCard.tsx` — uses shared StarRating
- `apps/web/src/components/MobileTasksView/components/JobPreviewCard.tsx` — uses shared StarRating

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/107?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->