### PR TITLE
feat: Add light theme support to Landing Page

### DIFF
--- a/apps/web/src/pages/LandingPage/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage/LandingPage.tsx
@@ -9,10 +9,10 @@ import {
 
 export default function LandingPage() {
   return (
-    <div className="bg-[#0a0a0f] min-h-screen">
+    <div className="bg-gray-50 dark:bg-[#0a0a0f] min-h-screen">
       {/* Hero Section */}
       <section className="relative overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-br from-blue-600/20 via-transparent to-green-600/10" />
+        <div className="absolute inset-0 bg-gradient-to-br from-blue-600/10 via-transparent to-green-600/5 dark:from-blue-600/20 dark:via-transparent dark:to-green-600/10" />
         <div className="relative max-w-6xl mx-auto px-4 py-8 sm:py-12 md:py-16 lg:py-24">
           <div className="lg:grid lg:grid-cols-2 gap-12 items-center">
             <HeroSection />

--- a/apps/web/src/pages/LandingPage/components/CTASection.tsx
+++ b/apps/web/src/pages/LandingPage/components/CTASection.tsx
@@ -5,12 +5,12 @@ const CTASection = () => {
   const { t } = useTranslation();
 
   return (
-    <section className="py-12 sm:py-16 md:py-24 border-t border-[#1a1a24]">
+    <section className="py-12 sm:py-16 md:py-24 border-t border-gray-200 dark:border-[#1a1a24]">
       <div className="max-w-2xl mx-auto px-4 text-center">
-        <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold text-white mb-3 sm:mb-4">
+        <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-3 sm:mb-4">
           {t('landing.cta.title')}
         </h2>
-        <p className="text-gray-400 text-base sm:text-lg mb-6 sm:mb-8">
+        <p className="text-gray-600 dark:text-gray-400 text-base sm:text-lg mb-6 sm:mb-8">
           {t('landing.cta.subtitle')}
         </p>
         <a

--- a/apps/web/src/pages/LandingPage/components/CategoriesSection.tsx
+++ b/apps/web/src/pages/LandingPage/components/CategoriesSection.tsx
@@ -13,21 +13,21 @@ const CategoriesSection = () => {
   ];
 
   return (
-    <section className="py-12 sm:py-16 md:py-24 border-t border-[#1a1a24]">
+    <section className="py-12 sm:py-16 md:py-24 border-t border-gray-200 dark:border-[#1a1a24]">
       <div className="max-w-6xl mx-auto px-4">
         <div className="text-center mb-8 sm:mb-12">
-          <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold text-white mb-3 sm:mb-4">{t('landing.categories.title')}</h2>
-          <p className="text-gray-400 text-base sm:text-lg">{t('landing.categories.subtitle')}</p>
+          <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-3 sm:mb-4">{t('landing.categories.title')}</h2>
+          <p className="text-gray-600 dark:text-gray-400 text-base sm:text-lg">{t('landing.categories.subtitle')}</p>
         </div>
 
         <div className="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-6 gap-3 sm:gap-4">
           {categories.map((cat, i) => (
             <div
               key={i}
-              className="bg-[#1a1a24]/50 hover:bg-[#1a1a24] border border-[#2a2a3a] hover:border-[#3a3a4a] rounded-xl p-3 sm:p-4 text-center transition-all group"
+              className="bg-gray-50 hover:bg-gray-100 dark:bg-[#1a1a24]/50 dark:hover:bg-[#1a1a24] border border-gray-200 hover:border-gray-300 dark:border-[#2a2a3a] dark:hover:border-[#3a3a4a] rounded-xl p-3 sm:p-4 text-center transition-all group"
             >
               <div className="text-2xl sm:text-3xl mb-1 sm:mb-2">{cat.icon}</div>
-              <div className="text-white font-medium text-xs sm:text-sm group-hover:text-blue-400 transition-colors">{cat.label}</div>
+              <div className="text-gray-900 dark:text-white font-medium text-xs sm:text-sm group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">{cat.label}</div>
               <div className="text-gray-500 text-[10px] sm:text-xs hidden sm:block">{cat.desc}</div>
             </div>
           ))}

--- a/apps/web/src/pages/LandingPage/components/HeroSection.tsx
+++ b/apps/web/src/pages/LandingPage/components/HeroSection.tsx
@@ -6,17 +6,17 @@ const HeroSection = () => {
 
   return (
     <div className="mb-8 lg:mb-0">
-      <div className="inline-flex items-center gap-2 px-3 lg:px-4 py-1.5 lg:py-2 bg-blue-500/10 border border-blue-500/20 rounded-full text-blue-400 text-xs lg:text-sm font-medium mb-4 lg:mb-6">
+      <div className="inline-flex items-center gap-2 px-3 lg:px-4 py-1.5 lg:py-2 bg-blue-500/10 border border-blue-500/20 rounded-full text-blue-600 dark:text-blue-400 text-xs lg:text-sm font-medium mb-4 lg:mb-6">
         <MapPin className="w-3 h-3 lg:w-4 lg:h-4" />
         {t('landing.hero.badge')}
       </div>
 
-      <h1 className="text-2xl sm:text-3xl lg:text-5xl xl:text-6xl font-bold text-white mb-3 lg:mb-6 leading-tight">
+      <h1 className="text-2xl sm:text-3xl lg:text-5xl xl:text-6xl font-bold text-gray-900 dark:text-white mb-3 lg:mb-6 leading-tight">
         {t('landing.hero.title')}
-        <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-green-400"> {t('landing.hero.titleHighlight')}</span>
+        <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-500 to-green-500 dark:from-blue-400 dark:to-green-400"> {t('landing.hero.titleHighlight')}</span>
       </h1>
 
-      <p className="text-base lg:text-xl text-gray-400 mb-6 lg:mb-8 leading-relaxed">
+      <p className="text-base lg:text-xl text-gray-600 dark:text-gray-400 mb-6 lg:mb-8 leading-relaxed">
         {t('landing.hero.subtitle')}
         <span className="hidden lg:inline">{t('landing.hero.subtitleExtended')}</span>
       </p>
@@ -24,19 +24,19 @@ const HeroSection = () => {
       <div className="grid grid-cols-3 gap-3 lg:flex lg:flex-wrap lg:gap-6 mb-8">
         <div className="text-center lg:text-left lg:flex lg:items-center lg:gap-2">
           <div className="w-10 h-10 bg-green-500/10 rounded-lg flex items-center justify-center mx-auto lg:mx-0 mb-1 lg:mb-0">
-            <Zap className="w-5 h-5 text-green-400" />
+            <Zap className="w-5 h-5 text-green-500 dark:text-green-400" />
           </div>
           <div>
-            <div className="text-white font-medium lg:font-semibold text-sm">{t('landing.hero.fast')}</div>
+            <div className="text-gray-900 dark:text-white font-medium lg:font-semibold text-sm">{t('landing.hero.fast')}</div>
             <div className="text-gray-500 text-xs lg:text-sm">{t('landing.hero.fastDesc')}</div>
           </div>
         </div>
         <div className="text-center lg:text-left lg:flex lg:items-center lg:gap-2">
           <div className="w-10 h-10 bg-blue-500/10 rounded-lg flex items-center justify-center mx-auto lg:mx-0 mb-1 lg:mb-0">
-            <Shield className="w-5 h-5 text-blue-400" />
+            <Shield className="w-5 h-5 text-blue-500 dark:text-blue-400" />
           </div>
           <div>
-            <div className="text-white font-medium lg:font-semibold text-sm">{t('landing.hero.verified')}</div>
+            <div className="text-gray-900 dark:text-white font-medium lg:font-semibold text-sm">{t('landing.hero.verified')}</div>
             <div className="text-gray-500 text-xs lg:text-sm">
               <span className="lg:hidden">{t('landing.hero.verifiedDesc')}</span>
               <span className="hidden lg:inline">{t('landing.hero.verifiedDescFull')}</span>
@@ -45,10 +45,10 @@ const HeroSection = () => {
         </div>
         <div className="text-center lg:text-left lg:flex lg:items-center lg:gap-2">
           <div className="w-10 h-10 bg-purple-500/10 rounded-lg flex items-center justify-center mx-auto lg:mx-0 mb-1 lg:mb-0">
-            <Star className="w-5 h-5 text-purple-400" />
+            <Star className="w-5 h-5 text-purple-500 dark:text-purple-400" />
           </div>
           <div>
-            <div className="text-white font-medium lg:font-semibold text-sm">{t('landing.hero.rated')}</div>
+            <div className="text-gray-900 dark:text-white font-medium lg:font-semibold text-sm">{t('landing.hero.rated')}</div>
             <div className="text-gray-500 text-xs lg:text-sm">{t('landing.hero.ratedDesc')}</div>
           </div>
         </div>

--- a/apps/web/src/pages/LandingPage/components/HowItWorksSection.tsx
+++ b/apps/web/src/pages/LandingPage/components/HowItWorksSection.tsx
@@ -16,30 +16,30 @@ const HowItWorksSection = () => {
   ];
 
   return (
-    <section className="py-12 sm:py-16 md:py-24 border-t border-[#1a1a24]">
+    <section className="py-12 sm:py-16 md:py-24 border-t border-gray-200 dark:border-[#1a1a24]">
       <div className="max-w-6xl mx-auto px-4">
         <div className="text-center mb-8 sm:mb-12">
-          <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold text-white mb-3 sm:mb-4">{t('landing.howItWorks.title')}</h2>
-          <p className="text-gray-400 text-base sm:text-lg max-w-2xl mx-auto">
+          <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-3 sm:mb-4">{t('landing.howItWorks.title')}</h2>
+          <p className="text-gray-600 dark:text-gray-400 text-base sm:text-lg max-w-2xl mx-auto">
             {t('landing.howItWorks.subtitle')}
           </p>
         </div>
 
         <div className="grid md:grid-cols-2 gap-6 lg:gap-16">
           {/* Need help? */}
-          <div className="bg-[#1a1a24]/50 rounded-2xl p-5 sm:p-6 md:p-8 border border-[#2a2a3a]">
-            <div className="inline-flex items-center gap-2 px-3 py-1 bg-blue-500/10 border border-blue-500/20 rounded-full text-blue-400 text-sm font-medium mb-5 sm:mb-6">
+          <div className="bg-gray-50 dark:bg-[#1a1a24]/50 rounded-2xl p-5 sm:p-6 md:p-8 border border-gray-200 dark:border-[#2a2a3a]">
+            <div className="inline-flex items-center gap-2 px-3 py-1 bg-blue-500/10 border border-blue-500/20 rounded-full text-blue-600 dark:text-blue-400 text-sm font-medium mb-5 sm:mb-6">
               {t('landing.howItWorks.needHelp')}
             </div>
             <div className="space-y-5 sm:space-y-6">
               {helpSteps.map((item) => (
                 <div key={item.num} className="flex gap-3 sm:gap-4">
                   <div className="w-9 h-9 sm:w-10 sm:h-10 bg-blue-500/10 rounded-xl flex items-center justify-center flex-shrink-0">
-                    <span className="text-blue-400 font-bold text-sm sm:text-base">{item.num}</span>
+                    <span className="text-blue-600 dark:text-blue-400 font-bold text-sm sm:text-base">{item.num}</span>
                   </div>
                   <div>
-                    <h3 className="text-white font-semibold mb-1 text-sm sm:text-base">{item.title}</h3>
-                    <p className="text-gray-400 text-xs sm:text-sm">{item.desc}</p>
+                    <h3 className="text-gray-900 dark:text-white font-semibold mb-1 text-sm sm:text-base">{item.title}</h3>
+                    <p className="text-gray-500 dark:text-gray-400 text-xs sm:text-sm">{item.desc}</p>
                   </div>
                 </div>
               ))}
@@ -47,19 +47,19 @@ const HowItWorksSection = () => {
           </div>
 
           {/* Want to earn? */}
-          <div className="bg-[#1a1a24]/50 rounded-2xl p-5 sm:p-6 md:p-8 border border-[#2a2a3a]">
-            <div className="inline-flex items-center gap-2 px-3 py-1 bg-green-500/10 border border-green-500/20 rounded-full text-green-400 text-sm font-medium mb-5 sm:mb-6">
+          <div className="bg-gray-50 dark:bg-[#1a1a24]/50 rounded-2xl p-5 sm:p-6 md:p-8 border border-gray-200 dark:border-[#2a2a3a]">
+            <div className="inline-flex items-center gap-2 px-3 py-1 bg-green-500/10 border border-green-500/20 rounded-full text-green-600 dark:text-green-400 text-sm font-medium mb-5 sm:mb-6">
               {t('landing.howItWorks.wantToEarn')}
             </div>
             <div className="space-y-5 sm:space-y-6">
               {earnSteps.map((item) => (
                 <div key={item.num} className="flex gap-3 sm:gap-4">
                   <div className="w-9 h-9 sm:w-10 sm:h-10 bg-green-500/10 rounded-xl flex items-center justify-center flex-shrink-0">
-                    <span className="text-green-400 font-bold text-sm sm:text-base">{item.num}</span>
+                    <span className="text-green-600 dark:text-green-400 font-bold text-sm sm:text-base">{item.num}</span>
                   </div>
                   <div>
-                    <h3 className="text-white font-semibold mb-1 text-sm sm:text-base">{item.title}</h3>
-                    <p className="text-gray-400 text-xs sm:text-sm">{item.desc}</p>
+                    <h3 className="text-gray-900 dark:text-white font-semibold mb-1 text-sm sm:text-base">{item.title}</h3>
+                    <p className="text-gray-500 dark:text-gray-400 text-xs sm:text-sm">{item.desc}</p>
                   </div>
                 </div>
               ))}

--- a/apps/web/src/pages/LandingPage/components/PhoneLoginCard.tsx
+++ b/apps/web/src/pages/LandingPage/components/PhoneLoginCard.tsx
@@ -53,18 +53,18 @@ const OTPDisplay = ({
         {[0, 1, 2, 3, 4, 5].map((index) => (
           <div
             key={index}
-            className={`w-10 h-12 sm:w-12 sm:h-14 flex items-center justify-center text-xl sm:text-2xl font-bold bg-[#0a0a0f] text-white rounded-lg border transition-colors ${
-              isFocused && index === digits.length ? 'border-blue-500' : digits[index] ? 'border-blue-500/50' : 'border-[#2a2a3a]'
+            className={`w-10 h-12 sm:w-12 sm:h-14 flex items-center justify-center text-xl sm:text-2xl font-bold bg-white dark:bg-[#0a0a0f] text-gray-900 dark:text-white rounded-lg border transition-colors ${
+              isFocused && index === digits.length ? 'border-blue-500' : digits[index] ? 'border-blue-500/50' : 'border-gray-300 dark:border-[#2a2a3a]'
             }`}
           >
             {digits[index] || ''}
-            {isFocused && index === digits.length && <span className="animate-pulse text-blue-400">|</span>}
+            {isFocused && index === digits.length && <span className="animate-pulse text-blue-500 dark:text-blue-400">|</span>}
           </div>
         ))}
       </div>
 
       {otpValue.length === 6 && loading && (
-        <p className="text-center text-blue-400 text-sm mt-2 flex items-center justify-center gap-2">
+        <p className="text-center text-blue-600 dark:text-blue-400 text-sm mt-2 flex items-center justify-center gap-2">
           <Loader2 className="w-4 h-4 animate-spin" /> {t('landing.login.verifying')}
         </p>
       )}
@@ -107,38 +107,38 @@ const PhoneLoginCard = () => {
   return (
     <div className="lg:pl-8">
       <div ref={recaptchaContainerRef} id="recaptcha-container-global" />
-      <div className="bg-[#1a1a24] rounded-2xl p-5 sm:p-6 lg:p-8 border border-[#2a2a3a] shadow-2xl">
+      <div className="bg-white dark:bg-[#1a1a24] rounded-2xl p-5 sm:p-6 lg:p-8 border border-gray-200 dark:border-[#2a2a3a] shadow-xl dark:shadow-2xl">
         <div className="text-center mb-5 lg:mb-6">
-          <h2 className="text-xl sm:text-2xl font-bold text-white mb-1 lg:mb-2">{t('landing.login.title')}</h2>
-          <p className="text-gray-400 text-sm lg:text-base">{t('landing.login.subtitle')}</p>
+          <h2 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white mb-1 lg:mb-2">{t('landing.login.title')}</h2>
+          <p className="text-gray-500 dark:text-gray-400 text-sm lg:text-base">{t('landing.login.subtitle')}</p>
         </div>
 
         {error && (
           <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-xl">
-            <p className="text-red-400 text-sm text-center">{error}</p>
+            <p className="text-red-600 dark:text-red-400 text-sm text-center">{error}</p>
           </div>
         )}
 
         {/* ===== PHONE LOGIN (default) ===== */}
         {step === 'phone' && !showEmailLogin && (
           <form onSubmit={handleSendCode}>
-            <label className="flex items-center gap-2 text-sm font-medium text-gray-300 mb-2">
+            <label className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               <Phone className="w-4 h-4" />
               {t('landing.login.phoneLabel')}
             </label>
 
             <div className="flex gap-2 mb-4">
-              <div className="flex items-center gap-1 sm:gap-2 px-3 sm:px-4 py-3 bg-[#0a0a0f] rounded-xl border border-[#2a2a3a] flex-shrink-0">
+              <div className="flex items-center gap-1 sm:gap-2 px-3 sm:px-4 py-3 bg-gray-50 dark:bg-[#0a0a0f] rounded-xl border border-gray-300 dark:border-[#2a2a3a] flex-shrink-0">
                 <span className="text-base sm:text-lg">🇱🇻</span>
-                <span className="text-gray-300 text-sm sm:text-base">+371</span>
-                <ChevronDown className="w-3 h-3 sm:w-4 sm:h-4 text-gray-500" />
+                <span className="text-gray-700 dark:text-gray-300 text-sm sm:text-base">+371</span>
+                <ChevronDown className="w-3 h-3 sm:w-4 sm:h-4 text-gray-400 dark:text-gray-500" />
               </div>
               <input
                 type="tel"
                 value={formatPhone(phoneNumber)}
                 onChange={(e) => setPhoneNumber(e.target.value.replace(/\D/g, ''))}
                 placeholder="20 000 000"
-                className="flex-1 min-w-0 px-3 sm:px-4 py-3 bg-[#0a0a0f] text-white rounded-xl border border-[#2a2a3a] focus:border-blue-500 focus:outline-none placeholder-gray-600 text-base sm:text-lg tracking-wide"
+                className="flex-1 min-w-0 px-3 sm:px-4 py-3 bg-gray-50 dark:bg-[#0a0a0f] text-gray-900 dark:text-white rounded-xl border border-gray-300 dark:border-[#2a2a3a] focus:border-blue-500 focus:outline-none placeholder-gray-400 dark:placeholder-gray-600 text-base sm:text-lg tracking-wide"
                 maxLength={11}
                 autoFocus
               />
@@ -147,7 +147,7 @@ const PhoneLoginCard = () => {
             <button
               type="submit"
               disabled={loading || phoneNumber.replace(/\D/g, '').length < 8 || !recaptchaReady}
-              className="w-full py-3.5 sm:py-4 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white font-semibold rounded-xl transition-colors flex items-center justify-center gap-2 mb-3"
+              className="w-full py-3.5 sm:py-4 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-700 disabled:cursor-not-allowed text-white font-semibold rounded-xl transition-colors flex items-center justify-center gap-2 mb-3"
             >
               {loading ? (
                 <><Loader2 className="w-5 h-5 animate-spin" /> {t('landing.login.sendingCode')}</>
@@ -161,7 +161,7 @@ const PhoneLoginCard = () => {
             <button
               type="button"
               onClick={() => navigate('/tasks')}
-              className="w-full py-3 border border-[#2a2a3a] hover:bg-[#0a0a0f] text-gray-300 font-medium rounded-xl transition-colors flex items-center justify-center gap-2 mb-4"
+              className="w-full py-3 border border-gray-300 dark:border-[#2a2a3a] hover:bg-gray-50 dark:hover:bg-[#0a0a0f] text-gray-700 dark:text-gray-300 font-medium rounded-xl transition-colors flex items-center justify-center gap-2 mb-4"
             >
               <MapIcon className="w-4 h-4" />
               {t('landing.login.browsing')}
@@ -169,17 +169,17 @@ const PhoneLoginCard = () => {
 
             <div className="relative my-5">
               <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-[#2a2a3a]"></div>
+                <div className="w-full border-t border-gray-200 dark:border-[#2a2a3a]"></div>
               </div>
               <div className="relative flex justify-center text-sm">
-                <span className="px-4 bg-[#1a1a24] text-gray-500">{t('landing.login.or')}</span>
+                <span className="px-4 bg-white dark:bg-[#1a1a24] text-gray-500">{t('landing.login.or')}</span>
               </div>
             </div>
 
             <button
               type="button"
               onClick={() => setShowEmailLogin(true)}
-              className="w-full py-3 border border-[#2a2a3a] hover:bg-[#0a0a0f] text-gray-300 font-medium rounded-xl transition-colors flex items-center justify-center gap-2"
+              className="w-full py-3 border border-gray-300 dark:border-[#2a2a3a] hover:bg-gray-50 dark:hover:bg-[#0a0a0f] text-gray-700 dark:text-gray-300 font-medium rounded-xl transition-colors flex items-center justify-center gap-2"
             >
               <Mail className="w-4 h-4" />
               {t('landing.login.emailLogin')}
@@ -193,7 +193,7 @@ const PhoneLoginCard = () => {
             <button
               type="button"
               onClick={() => setShowEmailLogin(false)}
-              className="flex items-center gap-1 text-sm text-blue-400 hover:text-blue-300 font-medium mb-4"
+              className="flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium mb-4"
             >
               <ArrowLeft className="w-4 h-4" />
               {t('auth.backToPhone', 'Back to phone sign in')}
@@ -201,13 +201,13 @@ const PhoneLoginCard = () => {
 
             {login.isError && (
               <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-xl">
-                <p className="text-red-400 text-sm text-center">{t('auth.loginError', 'Invalid email or password')}</p>
+                <p className="text-red-600 dark:text-red-400 text-sm text-center">{t('auth.loginError', 'Invalid email or password')}</p>
               </div>
             )}
 
             <form onSubmit={handleEmailSubmit} className="space-y-4">
               <div>
-                <label htmlFor="landing-email" className="flex items-center gap-2 text-sm font-medium text-gray-300 mb-1.5">
+                <label htmlFor="landing-email" className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                   <Mail className="w-4 h-4" /> {t('auth.email', 'Email')}
                 </label>
                 <input
@@ -216,15 +216,15 @@ const PhoneLoginCard = () => {
                   value={emailForm.email}
                   onChange={e => setEmailForm(prev => ({ ...prev, email: e.target.value }))}
                   placeholder="your@email.com"
-                  className="w-full px-4 py-3 bg-[#0a0a0f] text-white rounded-xl border border-[#2a2a3a] focus:border-blue-500 focus:outline-none placeholder-gray-600"
+                  className="w-full px-4 py-3 bg-gray-50 dark:bg-[#0a0a0f] text-gray-900 dark:text-white rounded-xl border border-gray-300 dark:border-[#2a2a3a] focus:border-blue-500 focus:outline-none placeholder-gray-400 dark:placeholder-gray-600"
                   required
                   autoFocus
                 />
               </div>
               <div>
                 <div className="flex items-center justify-between mb-1.5">
-                  <label htmlFor="landing-password" className="text-sm font-medium text-gray-300">{t('auth.password', 'Password')}</label>
-                  <Link to="/forgot-password" className="text-xs text-blue-400 hover:underline">{t('auth.forgot', 'Forgot?')}</Link>
+                  <label htmlFor="landing-password" className="text-sm font-medium text-gray-700 dark:text-gray-300">{t('auth.password', 'Password')}</label>
+                  <Link to="/forgot-password" className="text-xs text-blue-600 dark:text-blue-400 hover:underline">{t('auth.forgot', 'Forgot?')}</Link>
                 </div>
                 <div className="relative">
                   <input
@@ -233,13 +233,13 @@ const PhoneLoginCard = () => {
                     value={emailForm.password}
                     onChange={e => setEmailForm(prev => ({ ...prev, password: e.target.value }))}
                     placeholder="••••••••"
-                    className="w-full px-4 py-3 bg-[#0a0a0f] text-white rounded-xl border border-[#2a2a3a] focus:border-blue-500 focus:outline-none placeholder-gray-600 pr-12"
+                    className="w-full px-4 py-3 bg-gray-50 dark:bg-[#0a0a0f] text-gray-900 dark:text-white rounded-xl border border-gray-300 dark:border-[#2a2a3a] focus:border-blue-500 focus:outline-none placeholder-gray-400 dark:placeholder-gray-600 pr-12"
                     required
                   />
                   <button
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
                   >
                     {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
                   </button>
@@ -248,7 +248,7 @@ const PhoneLoginCard = () => {
               <button
                 type="submit"
                 disabled={login.isPending}
-                className="w-full py-3.5 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white font-semibold rounded-xl transition-colors flex items-center justify-center gap-2"
+                className="w-full py-3.5 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-700 disabled:cursor-not-allowed text-white font-semibold rounded-xl transition-colors flex items-center justify-center gap-2"
               >
                 {login.isPending ? (
                   <><Loader2 className="w-5 h-5 animate-spin" /> {t('auth.signingIn', 'Signing in...')}</>
@@ -263,8 +263,8 @@ const PhoneLoginCard = () => {
         {/* ===== STEP: OTP Code ===== */}
         {step === 'code' && (
           <div>
-            <p className="text-gray-400 text-sm text-center mb-4">
-              {t('landing.login.otpPrompt')} <span className="text-white">{getFullPhone()}</span>
+            <p className="text-gray-500 dark:text-gray-400 text-sm text-center mb-4">
+              {t('landing.login.otpPrompt')} <span className="text-gray-900 dark:text-white">{getFullPhone()}</span>
             </p>
 
             <OTPDisplay
@@ -277,7 +277,7 @@ const PhoneLoginCard = () => {
 
             <button
               onClick={resetToPhoneStep}
-              className="w-full mt-3 py-2 text-gray-400 hover:text-white text-sm"
+              className="w-full mt-3 py-2 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white text-sm"
             >
               {t('landing.login.changePhone')}
             </button>
@@ -286,8 +286,8 @@ const PhoneLoginCard = () => {
 
         <p className="text-xs text-gray-500 text-center mt-5 lg:mt-6">
           {t('landing.login.legal')}{' '}
-          <Link to="/terms" className="text-blue-400 hover:underline">{t('landing.login.terms')}</Link> {t('landing.login.and')}{' '}
-          <Link to="/privacy" className="text-blue-400 hover:underline">{t('landing.login.privacy')}</Link>
+          <Link to="/terms" className="text-blue-600 dark:text-blue-400 hover:underline">{t('landing.login.terms')}</Link> {t('landing.login.and')}{' '}
+          <Link to="/privacy" className="text-blue-600 dark:text-blue-400 hover:underline">{t('landing.login.privacy')}</Link>
         </p>
       </div>
     </div>

--- a/apps/web/src/pages/LandingPage/components/TrustSection.tsx
+++ b/apps/web/src/pages/LandingPage/components/TrustSection.tsx
@@ -2,9 +2,9 @@ import { Phone, Star, MessageCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 const colorMap: Record<string, { bg: string; text: string }> = {
-  blue: { bg: 'bg-blue-500/10', text: 'text-blue-400' },
-  yellow: { bg: 'bg-yellow-500/10', text: 'text-yellow-400' },
-  green: { bg: 'bg-green-500/10', text: 'text-green-400' },
+  blue: { bg: 'bg-blue-500/10', text: 'text-blue-600 dark:text-blue-400' },
+  yellow: { bg: 'bg-yellow-500/10', text: 'text-yellow-600 dark:text-yellow-400' },
+  green: { bg: 'bg-green-500/10', text: 'text-green-600 dark:text-green-400' },
 };
 
 const TrustSection = () => {
@@ -32,11 +32,11 @@ const TrustSection = () => {
   ];
 
   return (
-    <section className="py-12 sm:py-16 md:py-24 border-t border-[#1a1a24]">
+    <section className="py-12 sm:py-16 md:py-24 border-t border-gray-200 dark:border-[#1a1a24]">
       <div className="max-w-4xl mx-auto px-4">
         <div className="text-center mb-8 sm:mb-12">
-          <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold text-white mb-3 sm:mb-4">{t('landing.trust.title')}</h2>
-          <p className="text-gray-400 text-base sm:text-lg">{t('landing.trust.subtitle')}</p>
+          <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-3 sm:mb-4">{t('landing.trust.title')}</h2>
+          <p className="text-gray-600 dark:text-gray-400 text-base sm:text-lg">{t('landing.trust.subtitle')}</p>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
@@ -48,8 +48,8 @@ const TrustSection = () => {
                 <div className={`w-12 h-12 sm:w-14 sm:h-14 ${colors.bg} rounded-2xl flex items-center justify-center mx-auto mb-3 sm:mb-4`}>
                   <Icon className={`w-6 h-6 sm:w-7 sm:h-7 ${colors.text}`} />
                 </div>
-                <h3 className="text-white font-semibold mb-2 text-sm sm:text-base">{item.title}</h3>
-                <p className="text-gray-400 text-xs sm:text-sm">{item.desc}</p>
+                <h3 className="text-gray-900 dark:text-white font-semibold mb-2 text-sm sm:text-base">{item.title}</h3>
+                <p className="text-gray-500 dark:text-gray-400 text-xs sm:text-sm">{item.desc}</p>
               </div>
             );
           })}


### PR DESCRIPTION
## Summary

The landing page was previously hardcoded to dark mode only — all colors used fixed hex values like `#0a0a0f`, `#1a1a24`, `#2a2a3a`, and `text-white` without any light theme counterparts. This PR adds full light theme support so the landing page respects the user's system/app theme preference.

## What changed

All 7 landing page files were updated to use Tailwind's `dark:` variant strategy, replacing every hardcoded dark color with a `light dark:dark` pair:

| File | Changes |
|---|---|
| `LandingPage.tsx` | Root background `bg-gray-50 dark:bg-[#0a0a0f]` + lighter gradient for light mode |
| `HeroSection.tsx` | Headings, badge text, gradient highlight, feature card text |
| `HowItWorksSection.tsx` | Card backgrounds, borders, step numbers, headings, descriptions |
| `CategoriesSection.tsx` | Category grid cards, hover states, borders |
| `TrustSection.tsx` | Icon colors, headings, description text, colorMap updated |
| `CTASection.tsx` | Section border, heading, description text |
| `PhoneLoginCard.tsx` | Login card bg, all inputs, OTP boxes, buttons, divider, email form, labels, links |

## Color mapping used

| Dark (existing) | Light (new) | Element |
|---|---|---|
| `bg-[#0a0a0f]` | `bg-gray-50` / `bg-white` | Page bg, inputs |
| `bg-[#1a1a24]` | `bg-white` / `bg-gray-50` | Cards, panels |
| `border-[#1a1a24]` | `border-gray-200` | Section dividers |
| `border-[#2a2a3a]` | `border-gray-300` | Card/input borders |
| `border-[#3a3a4a]` | `border-gray-400` | Hover borders |
| `text-white` | `text-gray-900` | Headings, labels |
| `text-gray-400` | `text-gray-600` | Body text |
| `text-blue-400` | `text-blue-600` | Accent/link text |
| `disabled:bg-gray-700` | `disabled:bg-gray-300` | Disabled buttons |

## Design decisions

- Light mode uses `bg-gray-50` for the page background (matching the app's body style from `index.css`)
- Cards use `bg-white` in light mode with `shadow-xl` (vs `shadow-2xl` in dark) for depth
- Accent colors shift from `-400` (dark) to `-600` (light) for better contrast on white backgrounds
- The hero gradient is softened in light mode (`from-blue-600/10` vs `/20`)
- All changes are backward-compatible — dark mode looks identical to before

## Testing

- [ ] Toggle between light/dark mode — landing page should adapt
- [ ] Check all sections: Hero, Login Card (phone + email + OTP), How It Works, Categories, Trust, CTA
- [ ] Verify mobile responsiveness in both themes
- [ ] Confirm dark mode is pixel-identical to the previous version

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/114?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->