### PR TITLE
feat: Extend gradient background across entire landing page

### DIFF
--- a/apps/web/src/pages/LandingPage/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage/LandingPage.tsx
@@ -9,22 +9,32 @@ import {
 
 export default function LandingPage() {
   return (
-    <div className="bg-gray-50 dark:bg-[#0a0a0f] min-h-screen">
-      {/* Hero Section */}
-      <section className="relative overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-br from-blue-600/10 via-transparent to-green-600/5 dark:from-blue-600/20 dark:via-transparent dark:to-green-600/10" />
-        <div className="relative max-w-6xl mx-auto px-4 py-8 sm:py-12 md:py-16 lg:py-24">
-          <div className="lg:grid lg:grid-cols-2 gap-12 items-center">
-            <HeroSection />
-            <PhoneLoginCard />
-          </div>
-        </div>
-      </section>
+    <div className="relative bg-gray-50 dark:bg-[#0a0a0f] min-h-screen">
+      {/* Full-page gradient background */}
+      <div className="fixed inset-0 pointer-events-none">
+        {/* Light theme: soft blue-to-green wash */}
+        <div className="absolute inset-0 bg-gradient-to-br from-blue-100/80 via-white to-green-50/60 dark:hidden" />
+        {/* Dark theme: deep blue-to-green glow */}
+        <div className="absolute inset-0 hidden dark:block bg-gradient-to-br from-blue-600/20 via-transparent to-green-600/10" />
+      </div>
 
-      <HowItWorksSection />
-      <CategoriesSection />
-      <TrustSection />
-      <CTASection />
+      {/* Page content */}
+      <div className="relative">
+        {/* Hero Section */}
+        <section className="relative overflow-hidden">
+          <div className="relative max-w-6xl mx-auto px-4 py-8 sm:py-12 md:py-16 lg:py-24">
+            <div className="lg:grid lg:grid-cols-2 gap-12 items-center">
+              <HeroSection />
+              <PhoneLoginCard />
+            </div>
+          </div>
+        </section>
+
+        <HowItWorksSection />
+        <CategoriesSection />
+        <TrustSection />
+        <CTASection />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The blue/green gradient was previously limited to the hero section only. This PR extends it as a **full-page background** that flows through every section of the landing page, with different gradients for each theme.

## What changed

Only `LandingPage.tsx` was updated:

### Dark theme 🌙
- **Before**: gradient only behind hero (`bg-gradient-to-br from-blue-600/20 via-transparent to-green-600/10`)
- **After**: same gradient now covers the full viewport as a fixed background layer

### Light theme ☀️
- **Before**: plain `bg-gray-50` flat background
- **After**: soft `bg-gradient-to-br from-blue-100/80 via-white to-green-50/60` — a subtle blue-to-green wash that gives the page depth without being overpowering

## Implementation

- Gradient is rendered as a `fixed inset-0` layer with `pointer-events-none` so it doesn't interfere with clicks
- Two gradient divs: one visible in light mode (`dark:hidden`), one in dark mode (`hidden dark:block`)
- All page content is wrapped in a `relative` div to stack above the gradient
- The hero section's old inline gradient was removed (replaced by the full-page one)

## Testing

- [ ] Scroll through entire landing page in dark mode — gradient visible throughout
- [ ] Scroll through entire landing page in light mode — soft blue/green wash visible
- [ ] Verify no click/interaction issues (pointer-events-none on gradient layer)
- [ ] Check mobile scrolling behavior (fixed positioning)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/115?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->