### PR TITLE
feat: Add light theme support to Footer

### DIFF
--- a/apps/web/src/components/Layout/Footer.tsx
+++ b/apps/web/src/components/Layout/Footer.tsx
@@ -7,7 +7,7 @@ export default function Footer() {
 
   return (
     <footer 
-      className="bg-gradient-to-b from-slate-900 to-slate-950 dark:from-gray-900 dark:to-gray-950 text-slate-400 border-t-2 border-slate-700 dark:border-gray-700"
+      className="bg-gradient-to-b from-gray-100 to-gray-50 dark:from-gray-900 dark:to-gray-950 text-gray-500 dark:text-slate-400 border-t-2 border-gray-200 dark:border-gray-700"
       role="contentinfo"
       aria-label="Site footer"
     >
@@ -23,25 +23,25 @@ export default function Footer() {
                 alt="Kolab logo" 
                 className="w-10 h-10 rounded-xl shadow-lg"
               />
-              <span className="font-bold text-2xl text-white group-hover:text-blue-400 transition-colors">
+              <span className="font-bold text-2xl text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
                 Kolab
               </span>
             </Link>
-            <p className="text-slate-400 text-sm leading-relaxed">
+            <p className="text-gray-500 dark:text-slate-400 text-sm leading-relaxed">
               {t('home.heroSubtitle')}
             </p>
           </div>
 
           {/* Kolab Links */}
           <nav aria-label="Footer navigation - Kolab">
-            <h3 className="text-white font-semibold text-sm uppercase tracking-wider mb-5">
+            <h3 className="text-gray-900 dark:text-white font-semibold text-sm uppercase tracking-wider mb-5">
               Kolab
             </h3>
             <ul className="space-y-3" role="list">
               <li>
                 <Link 
                   to="/tasks" 
-                  className="text-slate-400 hover:text-white hover:translate-x-1 inline-flex transition-all duration-200"
+                  className="text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white hover:translate-x-1 inline-flex transition-all duration-200"
                 >
                   {t('tasks.browseTasks', 'Browse Tasks')}
                 </Link>
@@ -49,7 +49,7 @@ export default function Footer() {
               <li>
                 <Link 
                   to="/tasks/create" 
-                  className="text-slate-400 hover:text-white hover:translate-x-1 inline-flex transition-all duration-200"
+                  className="text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white hover:translate-x-1 inline-flex transition-all duration-200"
                 >
                   {t('tasks.createTask', 'Post a Job')}
                 </Link>
@@ -59,7 +59,7 @@ export default function Footer() {
 
           {/* Contact */}
           <div>
-            <h3 className="text-white font-semibold text-sm uppercase tracking-wider mb-5">
+            <h3 className="text-gray-900 dark:text-white font-semibold text-sm uppercase tracking-wider mb-5">
               {t('common.contact')}
             </h3>
             <address className="not-italic">
@@ -67,17 +67,17 @@ export default function Footer() {
                 <li>
                   <a 
                     href="mailto:info@kolab.lv" 
-                    className="flex items-center gap-2 text-slate-400 hover:text-white transition-colors group"
+                    className="flex items-center gap-2 text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white transition-colors group"
                     aria-label={t('footer.emailAriaLabel', 'Send email to info@kolab.lv')}
                   >
-                    <svg className="w-4 h-4 text-slate-500 group-hover:text-blue-400 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-4 h-4 text-gray-400 dark:text-slate-500 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                     </svg>
                     info@kolab.lv
                   </a>
                 </li>
                 <li className="flex items-center gap-2">
-                  <svg className="w-4 h-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-4 h-4 text-gray-400 dark:text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
                   </svg>
@@ -89,21 +89,21 @@ export default function Footer() {
         </div>
 
         {/* Bottom Bar */}
-        <div className="mt-12 pt-8 border-t border-slate-700 dark:border-gray-700">
+        <div className="mt-12 pt-8 border-t border-gray-200 dark:border-gray-700">
           <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
-            <p className="text-sm text-slate-500">
+            <p className="text-sm text-gray-400 dark:text-slate-500">
               &copy; {currentYear} Kolab. {t('footer.allRightsReserved', 'All rights reserved.')}
             </p>
             <div className="flex items-center gap-6 text-sm">
               <Link 
                 to="/terms" 
-                className="text-slate-500 hover:text-white transition-colors"
+                className="text-gray-400 dark:text-slate-500 hover:text-gray-900 dark:hover:text-white transition-colors"
               >
                 {t('legal.terms.title')}
               </Link>
               <Link 
                 to="/privacy" 
-                className="text-slate-500 hover:text-white transition-colors"
+                className="text-gray-400 dark:text-slate-500 hover:text-gray-900 dark:hover:text-white transition-colors"
               >
                 {t('legal.privacy.title')}
               </Link>


### PR DESCRIPTION
## Summary

The footer was always dark regardless of theme — it used `from-slate-900 to-slate-950` as the base background even in light mode. This PR adds proper light theme colors.

## Changes

| Element | Before (always dark) | Light theme (new) | Dark theme (preserved) |
|---|---|---|---|
| Background | `from-slate-900 to-slate-950` | `from-gray-100 to-gray-50` | `dark:from-gray-900 dark:to-gray-950` |
| Top border | `border-slate-700` | `border-gray-200` | `dark:border-gray-700` |
| Body text | `text-slate-400` | `text-gray-500` | `dark:text-slate-400` |
| Headings | `text-white` | `text-gray-900` | `dark:text-white` |
| Links | `hover:text-white` | `hover:text-gray-900` | `dark:hover:text-white` |
| Brand hover | `hover:text-blue-400` | `hover:text-blue-600` | `dark:group-hover:text-blue-400` |
| Icon color | `text-slate-500` | `text-gray-400` | `dark:text-slate-500` |
| Bottom bar border | `border-slate-700` | `border-gray-200` | `dark:border-gray-700` |
| Copyright text | `text-slate-500` | `text-gray-400` | `dark:text-slate-500` |
| Legal links | `text-slate-500` | `text-gray-400` | `dark:text-slate-500` |

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/116?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->