### PR TITLE
feat: add price/budget validation (€10 min, €10,000 max)

### DIFF
--- a/apps/web/src/pages/CreateOffering/components/PriceTypeSelector.tsx
+++ b/apps/web/src/pages/CreateOffering/components/PriceTypeSelector.tsx
@@ -49,18 +49,22 @@ const PriceTypeSelector = ({ value, price, onTypeChange, onPriceChange }: PriceT
       </div>
 
       {value !== 'negotiable' ? (
-        <div className="relative">
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500 text-sm font-medium">€</span>
-          <input
-            type="number"
-            name="price"
-            step="0.01"
-            min="0"
-            value={price}
-            onChange={onPriceChange}
-            placeholder={t('createOffering.pricePlaceholder', value === 'hourly' ? 'e.g., 15' : 'e.g., 50')}
-            className="w-full pl-7 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-amber-500 focus:border-transparent text-base sm:text-sm placeholder:text-gray-400 dark:placeholder:text-gray-500"
-          />
+        <div>
+          <div className="relative">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500 text-sm font-medium">€</span>
+            <input
+              type="number"
+              name="price"
+              step="0.01"
+              min="10"
+              max="10000"
+              value={price}
+              onChange={onPriceChange}
+              placeholder={t('createOffering.pricePlaceholder', value === 'hourly' ? 'e.g., 15' : 'e.g., 50')}
+              className="w-full pl-7 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-amber-500 focus:border-transparent text-base sm:text-sm placeholder:text-gray-400 dark:placeholder:text-gray-500"
+            />
+          </div>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">{t('createOffering.priceHint', 'Min €10, max €10,000')}</p>
         </div>
       ) : (
         <p className="text-xs text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 rounded-lg px-3 py-2">

--- a/apps/web/src/pages/CreateOffering/hooks/useOfferingForm.ts
+++ b/apps/web/src/pages/CreateOffering/hooks/useOfferingForm.ts
@@ -128,6 +128,15 @@ export const useOfferingForm = () => {
       return;
     }
 
+    // Price range validation (skip for negotiable)
+    if (formData.price_type !== 'negotiable') {
+      const priceNum = formData.price ? parseFloat(formData.price) : 0;
+      if (!formData.price || isNaN(priceNum) || priceNum < 10 || priceNum > 10000) {
+        toast.error(t('createOffering.priceRange', 'Price must be between €10 and €10,000'));
+        return;
+      }
+    }
+
     setLoading(true);
 
     try {

--- a/apps/web/src/pages/CreateTask/components/BudgetInput.tsx
+++ b/apps/web/src/pages/CreateTask/components/BudgetInput.tsx
@@ -18,14 +18,15 @@ const BudgetInput = ({ value, onChange }: BudgetInputProps) => {
         id="budget"
         name="budget"
         step="0.01"
-        min="0"
+        min="10"
+        max="10000"
         required
         value={value}
         onChange={onChange}
         placeholder={t('createTask.budgetPlaceholder', 'e.g., 25.00')}
         className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent text-base sm:text-sm placeholder:text-gray-400 dark:placeholder:text-gray-500"
       />
-      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">{t('createTask.budgetHint', 'How much are you willing to pay for this task?')}</p>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">{t('createTask.budgetHint', 'Min €10, max €10,000. How much are you willing to pay for this task?')}</p>
     </div>
   );
 };

--- a/apps/web/src/pages/CreateTask/hooks/useTaskForm.ts
+++ b/apps/web/src/pages/CreateTask/hooks/useTaskForm.ts
@@ -157,6 +157,13 @@ export const useTaskForm = () => {
       return;
     }
 
+    // Budget range validation
+    const budgetNum = formData.budget ? parseFloat(formData.budget) : 0;
+    if (!formData.budget || isNaN(budgetNum) || budgetNum < 10 || budgetNum > 10000) {
+      toast.error(t('createTask.budgetRange', 'Budget must be between €10 and €10,000'));
+      return;
+    }
+
     setLoading(true);
     const hasValidCoords = await ensureCoordinates();
     if (!hasValidCoords) {

--- a/apps/web/src/pages/EditOffering/components/PriceEditor.tsx
+++ b/apps/web/src/pages/EditOffering/components/PriceEditor.tsx
@@ -23,12 +23,14 @@ const PriceEditor = ({ price, priceType, onChange }: PriceEditorProps) => {
             id="price"
             name="price"
             step="0.01"
-            min="0"
+            min="10"
+            max="10000"
             value={price}
             onChange={onChange}
             placeholder={t('editOffering.pricePlaceholder', 'e.g., 20.00')}
             className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-amber-500 focus:border-transparent placeholder:text-gray-400 dark:placeholder:text-gray-500"
           />
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">{t('editOffering.priceHint', 'Min €10, max €10,000')}</p>
         </div>
         <div>
           <label htmlFor="price_type" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">

--- a/apps/web/src/pages/EditOffering/hooks/useEditOfferingForm.ts
+++ b/apps/web/src/pages/EditOffering/hooks/useEditOfferingForm.ts
@@ -127,6 +127,15 @@ export const useEditOfferingForm = () => {
       return;
     }
 
+    // Price range validation (skip for negotiable)
+    if (formData.price_type !== 'negotiable') {
+      const priceNum = formData.price ? parseFloat(formData.price) : 0;
+      if (!formData.price || isNaN(priceNum) || priceNum < 10 || priceNum > 10000) {
+        toast.error(t('editOffering.priceRange', 'Price must be between €10 and €10,000'));
+        return;
+      }
+    }
+
     setSaving(true);
     try {
       const updateData = {

--- a/apps/web/src/pages/EditTask/EditTask.tsx
+++ b/apps/web/src/pages/EditTask/EditTask.tsx
@@ -111,14 +111,15 @@ const EditTask = () => {
                 id="budget"
                 name="budget"
                 step="0.01"
-                min="0"
+                min="10"
+                max="10000"
                 required
                 value={formData.budget}
                 onChange={handleChange}
                 placeholder={t('editTask.budgetPlaceholder', 'e.g., 25.00')}
                 className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder:text-gray-400 dark:placeholder:text-gray-500"
               />
-              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">{t('editTask.budgetHint', 'How much are you willing to pay for this task?')}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">{t('editTask.budgetHint', 'Min €10, max €10,000')}</p>
             </div>
 
             {/* Deadline */}

--- a/apps/web/src/pages/EditTask/hooks/useEditTaskForm.ts
+++ b/apps/web/src/pages/EditTask/hooks/useEditTaskForm.ts
@@ -137,6 +137,13 @@ export const useEditTaskForm = () => {
       return;
     }
 
+    // Budget range validation
+    const budgetNum = formData.budget ? parseFloat(formData.budget) : 0;
+    if (!formData.budget || isNaN(budgetNum) || budgetNum < 10 || budgetNum > 10000) {
+      toast.error(t('editTask.budgetRange', 'Budget must be between €10 and €10,000'));
+      return;
+    }
+
     setSaving(true);
     try {
       const updateData = {


### PR DESCRIPTION
## What

Adds **€10 minimum** and **€10,000 maximum** validation to all price/budget inputs across Create and Edit forms for both Tasks and Offerings.

## Why

Users have been entering invalid values (too many digits, zero amounts, etc.) because there were no limits enforced anywhere.

## Changes

### HTML Input Constraints
- `BudgetInput.tsx` — `min="10"` `max="10000"` (CreateTask)
- `PriceTypeSelector.tsx` — `min="10"` `max="10000"` (CreateOffering)
- `EditTask.tsx` — `min="10"` `max="10000"`
- `PriceEditor.tsx` — `min="10"` `max="10000"` (EditOffering)

### JavaScript Submit Validation
- `useTaskForm.ts` — budget range check before API call
- `useOfferingForm.ts` — price range check (skipped for negotiable)
- `useEditTaskForm.ts` — budget range check before API call
- `useEditOfferingForm.ts` — price range check (skipped for negotiable)

### Hint Text
- Updated budget/price hints to show "Min €10, max €10,000"

> ⚠️ **Note:** i18n translation keys for LV/RU still need to be added. The fallback English strings are in place.

Closes #121

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/122?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->