### PR TITLE
fix: remove legacy duplicate categories from job alert settings

### DIFF
--- a/apps/web/src/pages/Profile/components/tabs/settings/JobAlertSettings.tsx
+++ b/apps/web/src/pages/Profile/components/tabs/settings/JobAlertSettings.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getJobAlertPreferences, updateJobAlertPreferences } from '@marketplace/shared';
 import type { JobAlertPreferences, UpdateJobAlertPayload } from '@marketplace/shared';
-import { TASK_CATEGORIES, CATEGORY_ICONS } from './settingsConstants';
+import { TASK_CATEGORIES, getCategoryIcon } from './settingsConstants';
 
 /* ─── Shared location cache (same key & format as useUserLocation) ─── */
 const LOCATION_CACHE_KEY = 'user_last_location';
@@ -345,7 +345,7 @@ export const JobAlertSettings = () => {
                           } disabled:opacity-50`}
                         >
                           <span className="w-5 h-5 flex items-center justify-center flex-shrink-0 text-base leading-none" role="img" aria-label={cat}>
-                            {CATEGORY_ICONS[cat] || '\uD83D\uDCCB'}
+                            {getCategoryIcon(cat)}
                           </span>
                           <span>{t(`common.categories.${cat}`, cat)}</span>
                           {isSelected && (

--- a/apps/web/src/pages/Profile/components/tabs/settings/settingsConstants.ts
+++ b/apps/web/src/pages/Profile/components/tabs/settings/settingsConstants.ts
@@ -1,3 +1,5 @@
+import { FORM_CATEGORIES, getCategoryIcon } from '@marketplace/shared';
+
 export const languages = [
   { code: 'lv', label: 'LV', name: 'Latviešu', flag: '🇱🇻' },
   { code: 'ru', label: 'RU', name: 'Русский', flag: '🇷🇺' },
@@ -31,52 +33,13 @@ export const themeOptions = [
   },
 ];
 
-// All categories used across both tasks and offerings.
-// Task-creation categories: pet-care, moving, shopping, cleaning, delivery,
-//   outdoor, handyman, tutoring, tech-help, other
-// Offering-specific categories: assembly, plumbing, electrical, painting,
-//   care, tech, beauty, events
-export const TASK_CATEGORIES = [
-  'cleaning',
-  'handyman',
-  'delivery',
-  'moving',
-  'outdoor',
-  'pet-care',
-  'tutoring',
-  'tech-help',
-  'shopping',
-  'assembly',
-  'plumbing',
-  'electrical',
-  'painting',
-  'care',
-  'tech',
-  'beauty',
-  'events',
-  'other',
-] as const;
+// Job alert category chips — sourced from shared package (single source of truth).
+// FORM_CATEGORIES has the 15 canonical keys used by Create Task form.
+// This ensures alert prefs use the same keys as tasks in the database.
+export const TASK_CATEGORIES = FORM_CATEGORIES.map(c => c.key);
 
-export const CATEGORY_ICONS: Record<string, string> = {
-  'cleaning': '🧹',
-  'handyman': '🔧',
-  'delivery': '🚗',
-  'moving': '📦',
-  'outdoor': '🌿',
-  'pet-care': '🐕',
-  'tutoring': '📚',
-  'tech-help': '💻',
-  'shopping': '🛒',
-  'assembly': '🪑',
-  'plumbing': '🔩',
-  'electrical': '⚡',
-  'painting': '🎨',
-  'care': '❤️',
-  'tech': '🖥️',
-  'beauty': '💇',
-  'events': '🎉',
-  'other': '📋',
-};
+// Re-export shared icon lookup so JobAlertSettings doesn't need a direct import
+export { getCategoryIcon };
 
 export const isIOSSafari = () => {
   const ua = navigator.userAgent;


### PR DESCRIPTION
## Problem

The Job Alerts category picker in Settings showed **18 chips** with 3 legacy duplicates:
- `Pet Care` (`pet-care`) AND `Care` (`care`)
- `Shopping` (`shopping`) AND `Delivery` (`delivery`)
- `Tech Help` (`tech-help`) AND `Tech` (`tech`)

If a user selected a legacy key (e.g. `pet-care`), it would be saved to their preferences. But tasks created via "Create New Job" use the canonical key (`care`) from `@marketplace/shared`. The backend `job_alerts.py` does a direct `task.category not in allowed_categories` check — so `care` ∉ `['pet-care']` → **no notification sent**.

Meanwhile, the Create New Job form correctly shows only 15 categories from the shared package.

## Root Cause

`settingsConstants.ts` had a hardcoded `TASK_CATEGORIES` array and `CATEGORY_ICONS` map that were **not sourced from `@marketplace/shared`**. They included both legacy and canonical keys.

## Fix

- **`settingsConstants.ts`**: Replace hardcoded `TASK_CATEGORIES` (18 items) with `FORM_CATEGORIES.map(c => c.key)` from `@marketplace/shared` (15 canonical items). Remove `CATEGORY_ICONS` in favor of shared `getCategoryIcon()`.
- **`JobAlertSettings.tsx`**: Import `getCategoryIcon` from settingsConstants and use it for chip icons instead of the old `CATEGORY_ICONS[cat]` lookup.

## Result

| Before | After |
|--------|-------|
| 18 chips (3 legacy duplicates) | 15 clean canonical chips |
| Selecting `Pet Care` saves `pet-care` → no match | Selecting `Care` saves `care` → ✅ matches |
| Selecting `Shopping` saves `shopping` → no match | Selecting `Delivery` saves `delivery` → ✅ matches |
| Selecting `Tech Help` saves `tech-help` → no match | Selecting `Tech` saves `tech` → ✅ matches |

Job alert category chips now match the Create New Job form exactly.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/128?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->