### PR TITLE
fix: use loadEnv to properly read .env in vite config

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,160 +1,165 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 
-export default defineConfig({
-  // Define global constants that get replaced at build time
-  // This avoids import.meta usage which doesn't work in React Native/Hermes
-  define: {
-    __VITE_API_URL__: JSON.stringify(process.env.VITE_API_URL || '')
-  },
-  plugins: [
-    react(),
-    VitePWA({
-      registerType: 'autoUpdate',
-      includeAssets: [
-        'favicon-32x32.png',
-        'favicon-16x16.png',
-        'apple-touch-icon.png',
-        'apple-touch-icon-180x180.png',
-        'apple-touch-icon-152x152.png',
-        'apple-touch-icon-120x120.png',
-        'apple-touch-icon-180x180-precomposed.png',
-        'apple-touch-icon-152x152-precomposed.png',
-        'apple-touch-icon-120x120-precomposed.png',
-        'android-chrome-192x192.png',
-        'android-chrome-512x512.png',
-        'logo.png',
-        'sw-push.js'
-      ],
-      manifest: {
-        name: 'Kolab',
-        short_name: 'Kolab',
-        description: 'Earn money by helping others with everyday tasks.',
-        start_url: '/',
-        scope: '/',
-        id: '/',
-        display: 'standalone',
-        background_color: '#030712',
-        theme_color: '#111827',
-        orientation: 'portrait-primary',
-        lang: 'en',
-        categories: ['business', 'lifestyle', 'productivity'],
-        icons: [
-          {
-            src: 'apple-touch-icon.png',
-            sizes: '180x180',
-            type: 'image/png',
-            purpose: 'any'
-          },
-          {
-            src: 'apple-touch-icon-180x180.png',
-            sizes: '180x180',
-            type: 'image/png',
-            purpose: 'any'
-          },
-          {
-            src: 'apple-touch-icon-152x152.png',
-            sizes: '152x152',
-            type: 'image/png',
-            purpose: 'any'
-          },
-          {
-            src: 'apple-touch-icon-120x120.png',
-            sizes: '120x120',
-            type: 'image/png',
-            purpose: 'any'
-          },
-          {
-            src: 'android-chrome-192x192.png',
-            sizes: '192x192',
-            type: 'image/png',
-            purpose: 'any'
-          },
-          {
-            src: 'android-chrome-512x512.png',
-            sizes: '512x512',
-            type: 'image/png',
-            purpose: 'any'
-          },
-          {
-            src: 'android-chrome-512x512.png',
-            sizes: '512x512',
-            type: 'image/png',
-            purpose: 'maskable'
-          }
-        ]
-      },
-      workbox: {
-        importScripts: ['/sw-push.js'],
-        navigateFallbackDenylist: [/^\/api\/.*/],
-        globPatterns: ['**/*.{js,css,html,png}'],
-        cleanupOutdatedCaches: true,
-        runtimeCaching: [
-          {
-            urlPattern: /^https:\/\/api\.dicebear\.com\/.*/i,
-            handler: 'CacheFirst',
-            options: {
-              cacheName: 'dicebear-avatars',
-              expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 60 * 60 * 24 * 30
-              },
-              cacheableResponse: {
-                statuses: [0, 200]
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const apiUrl = env.VITE_API_URL || 'http://localhost:5000'
+
+  return {
+    // Define global constants that get replaced at build time
+    // This avoids import.meta usage which doesn't work in React Native/Hermes
+    define: {
+      __VITE_API_URL__: JSON.stringify(apiUrl)
+    },
+    plugins: [
+      react(),
+      VitePWA({
+        registerType: 'autoUpdate',
+        includeAssets: [
+          'favicon-32x32.png',
+          'favicon-16x16.png',
+          'apple-touch-icon.png',
+          'apple-touch-icon-180x180.png',
+          'apple-touch-icon-152x152.png',
+          'apple-touch-icon-120x120.png',
+          'apple-touch-icon-180x180-precomposed.png',
+          'apple-touch-icon-152x152-precomposed.png',
+          'apple-touch-icon-120x120-precomposed.png',
+          'android-chrome-192x192.png',
+          'android-chrome-512x512.png',
+          'logo.png',
+          'sw-push.js'
+        ],
+        manifest: {
+          name: 'Kolab',
+          short_name: 'Kolab',
+          description: 'Earn money by helping others with everyday tasks.',
+          start_url: '/',
+          scope: '/',
+          id: '/',
+          display: 'standalone',
+          background_color: '#030712',
+          theme_color: '#111827',
+          orientation: 'portrait-primary',
+          lang: 'en',
+          categories: ['business', 'lifestyle', 'productivity'],
+          icons: [
+            {
+              src: 'apple-touch-icon.png',
+              sizes: '180x180',
+              type: 'image/png',
+              purpose: 'any'
+            },
+            {
+              src: 'apple-touch-icon-180x180.png',
+              sizes: '180x180',
+              type: 'image/png',
+              purpose: 'any'
+            },
+            {
+              src: 'apple-touch-icon-152x152.png',
+              sizes: '152x152',
+              type: 'image/png',
+              purpose: 'any'
+            },
+            {
+              src: 'apple-touch-icon-120x120.png',
+              sizes: '120x120',
+              type: 'image/png',
+              purpose: 'any'
+            },
+            {
+              src: 'android-chrome-192x192.png',
+              sizes: '192x192',
+              type: 'image/png',
+              purpose: 'any'
+            },
+            {
+              src: 'android-chrome-512x512.png',
+              sizes: '512x512',
+              type: 'image/png',
+              purpose: 'any'
+            },
+            {
+              src: 'android-chrome-512x512.png',
+              sizes: '512x512',
+              type: 'image/png',
+              purpose: 'maskable'
+            }
+          ]
+        },
+        workbox: {
+          importScripts: ['/sw-push.js'],
+          navigateFallbackDenylist: [/^\/api\/.*/],
+          globPatterns: ['**/*.{js,css,html,png}'],
+          cleanupOutdatedCaches: true,
+          runtimeCaching: [
+            {
+              urlPattern: /^https:\/\/api\.dicebear\.com\/.*/i,
+              handler: 'CacheFirst',
+              options: {
+                cacheName: 'dicebear-avatars',
+                expiration: {
+                  maxEntries: 50,
+                  maxAgeSeconds: 60 * 60 * 24 * 30
+                },
+                cacheableResponse: {
+                  statuses: [0, 200]
+                }
+              }
+            },
+            {
+              urlPattern: /^https:\/\/.*\.tile\.openstreetmap\.org\/.*/i,
+              handler: 'CacheFirst',
+              options: {
+                cacheName: 'map-tiles',
+                expiration: {
+                  maxEntries: 80,
+                  maxAgeSeconds: 60 * 60 * 24 * 7
+                },
+                cacheableResponse: {
+                  statuses: [0, 200]
+                }
+              }
+            },
+            {
+              urlPattern: /\/uploads\/.*/i,
+              handler: 'CacheFirst',
+              options: {
+                cacheName: 'uploaded-images',
+                expiration: {
+                  maxEntries: 50,
+                  maxAgeSeconds: 60 * 60 * 24 * 30
+                },
+                cacheableResponse: {
+                  statuses: [0, 200]
+                }
               }
             }
-          },
-          {
-            urlPattern: /^https:\/\/.*\.tile\.openstreetmap\.org\/.*/i,
-            handler: 'CacheFirst',
-            options: {
-              cacheName: 'map-tiles',
-              expiration: {
-                maxEntries: 80,
-                maxAgeSeconds: 60 * 60 * 24 * 7
-              },
-              cacheableResponse: {
-                statuses: [0, 200]
-              }
-            }
-          },
-          {
-            urlPattern: /\/uploads\/.*/i,
-            handler: 'CacheFirst',
-            options: {
-              cacheName: 'uploaded-images',
-              expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 60 * 60 * 24 * 30
-              },
-              cacheableResponse: {
-                statuses: [0, 200]
-              }
-            }
-          }
-        ]
-      },
-      devOptions: {
-        enabled: false
+          ]
+        },
+        devOptions: {
+          enabled: false
+        }
+      })
+    ],
+    optimizeDeps: {
+      exclude: ['react-native']
+    },
+    resolve: {
+      alias: {
+        'react-native': 'react-native-web'
       }
-    })
-  ],
-  optimizeDeps: {
-    exclude: ['react-native']
-  },
-  resolve: {
-    alias: {
-      'react-native': 'react-native-web'
-    }
-  },
-  server: {
-    port: 3000,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:5000',
-        changeOrigin: true,
+    },
+    server: {
+      port: 3000,
+      proxy: {
+        '/api': {
+          target: apiUrl,
+          changeOrigin: true,
+        },
       },
     },
-  },
+  }
 })


### PR DESCRIPTION
## Problem

`vite.config.ts` used `process.env.VITE_API_URL` to set the `__VITE_API_URL__` build constant. However, Vite loads `.env` files **after** config resolution, so `process.env` doesn't have `.env` values inside the config file. This means:

- `process.env.VITE_API_URL` is always `undefined` in the config
- `__VITE_API_URL__` falls back to `''` (empty string)
- The shared package's `client.ts` then falls back to `localhost:5000`

## Fix

- Import `loadEnv` from Vite and use the function form of `defineConfig`
- Call `loadEnv(mode, process.cwd(), '')` to load `.env` values before config resolution
- Use the loaded `apiUrl` for both `__VITE_API_URL__` define and the dev server proxy target
- Dev proxy now stays in sync with the API URL automatically

## Behavior

| Environment | Source | URL |
|---|---|---|
| Production deploy | Host env var `VITE_API_URL` | Set by CI/host |
| Local dev with `.env` | `.env` file | Whatever's in `.env` |
| Local dev without `.env` | Fallback | `http://localhost:5000` |

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/138?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->