### PR TITLE
fix: reset Zustand stores on logout to prevent cross-session data leaks

### DIFF
--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { authApi } from '@marketplace/shared'
-import { useAuthStore } from '@marketplace/shared'
+import { useAuthStore, useFavoritesStore, useMatchingStore } from '@marketplace/shared'
 import type { LoginCredentials, RegisterData } from '@marketplace/shared'
 import { queryClient } from '../lib/queryClient'
 
@@ -36,11 +36,17 @@ export function useRegister() {
 export function useLogout() {
   const navigate = useNavigate()
   const logout = useAuthStore((state) => state.logout)
+  const clearFavorites = useFavoritesStore((state) => state.clearCache)
+  const resetMatching = useMatchingStore((state) => state.reset)
 
   return () => {
     // Clear all React Query caches to prevent stale user-specific data
     // (messages, tasks, notifications, profile) from leaking across sessions
     queryClient.clear()
+    // Reset Zustand stores that hold user-specific data
+    clearFavorites()
+    resetMatching()
+    // Clear auth state last
     logout()
     navigate('/')
   }

--- a/packages/shared/src/stores/matchingStore.ts
+++ b/packages/shared/src/stores/matchingStore.ts
@@ -18,20 +18,21 @@ interface MatchingState {
   // User's offering categories (for matching jobs)
   myOfferingCategories: string[];
   myOfferings: Offering[];
-  
+
   // Notifications
   notifications: MatchNotification[];
   unreadCount: number;
-  
+
   // Last check timestamp
   lastChecked: string | null;
-  
+
   // Actions
   loadMyOfferings: () => Promise<void>;
   addNotification: (notification: Omit<MatchNotification, 'id' | 'createdAt' | 'read'>) => void;
   markAsRead: (id: string) => void;
   markAllAsRead: () => void;
   clearNotifications: () => void;
+  reset: () => void;
   isJobMatchingMyOfferings: (jobCategory: string) => boolean;
   getMatchingOfferingsForJob: (jobCategory: string) => Offering[];
 }
@@ -50,7 +51,7 @@ export const useMatchingStore = create<MatchingState>()(
           const response = await getMyOfferings();
           const offerings = response.offerings || [];
           const categories = [...new Set(offerings.map(o => o.category))];
-          
+
           set({
             myOfferings: offerings,
             myOfferingCategories: categories,
@@ -68,7 +69,7 @@ export const useMatchingStore = create<MatchingState>()(
           createdAt: new Date(),
           read: false
         };
-        
+
         set(state => ({
           notifications: [newNotification, ...state.notifications].slice(0, 50), // Keep last 50
           unreadCount: state.unreadCount + 1
@@ -80,7 +81,7 @@ export const useMatchingStore = create<MatchingState>()(
           const notification = state.notifications.find(n => n.id === id);
           if (notification && !notification.read) {
             return {
-              notifications: state.notifications.map(n => 
+              notifications: state.notifications.map(n =>
                 n.id === id ? { ...n, read: true } : n
               ),
               unreadCount: Math.max(0, state.unreadCount - 1)
@@ -101,6 +102,16 @@ export const useMatchingStore = create<MatchingState>()(
         set({
           notifications: [],
           unreadCount: 0
+        });
+      },
+
+      reset: () => {
+        set({
+          myOfferingCategories: [],
+          myOfferings: [],
+          notifications: [],
+          unreadCount: 0,
+          lastChecked: null,
         });
       },
 


### PR DESCRIPTION
## Problem

When User A logs out and User B logs in, the Zustand stores still hold User A's data:

- **`favoritesStore`** — User A's favorites cache persists in memory
- **`matchingStore`** — User A's offerings, categories, notifications, and unread count persist (and `myOfferingCategories` is even saved to localStorage via `partialize`)

This means User B would see User A's favorites and matching state until a full page refresh or until the data is overwritten by new API calls.

## Fix

### `matchingStore.ts`
- Added `reset()` method that clears **all** user-specific state: `myOfferingCategories`, `myOfferings`, `notifications`, `unreadCount`, `lastChecked`
- Note: the existing `clearNotifications()` only cleared notifications and unreadCount — it missed offerings/categories

### `useAuth.ts`
- `useLogout()` now calls `favoritesStore.clearCache()` and `matchingStore.reset()` alongside the existing `queryClient.clear()` and `authStore.logout()`

## Full logout cleanup chain

| Layer | Method | Status |
|---|---|---|
| React Query cache | `queryClient.clear()` | ✅ PR #137 |
| Favorites (Zustand) | `clearCache()` | ✅ This PR |
| Matching (Zustand, persisted) | `reset()` | ✅ This PR |
| Auth (Zustand, persisted) | `logout()` | ✅ Already worked |
| Toasts (Zustand) | N/A — ephemeral UI | ✅ No action needed |

Relates to #139

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/142?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->