### PR TITLE
perf: lazy-load map popup content + cache marker icons

### DIFF
--- a/apps/web/src/pages/Tasks/components/Map/LazyPopupMarker.tsx
+++ b/apps/web/src/pages/Tasks/components/Map/LazyPopupMarker.tsx
@@ -1,0 +1,72 @@
+import { useRef, useState, useCallback } from 'react';
+import { Marker, Popup } from 'react-leaflet';
+import type { Marker as LeafletMarker } from 'leaflet';
+import type { Icon, DivIcon } from 'leaflet';
+
+interface LazyPopupMarkerProps {
+  position: [number, number];
+  icon: Icon | DivIcon;
+  popupProps?: {
+    maxWidth?: number;
+    minWidth?: number;
+    autoPan?: boolean;
+    autoPanPadding?: [number, number];
+    className?: string;
+  };
+  children: React.ReactNode;
+  markerKey: string;
+}
+
+/**
+ * A Marker that only renders its Popup children when opened.
+ * This avoids mounting heavy popup DOM for every marker on the map.
+ *
+ * How it works:
+ * 1. Marker renders with just an icon (cheap)
+ * 2. On click, Leaflet fires 'popupopen' → we set isOpen=true
+ * 3. React renders the popup children (JobMapPopup etc.)
+ * 4. On close, we set isOpen=false → children unmount
+ */
+const LazyPopupMarker = ({
+  position,
+  icon,
+  popupProps = {},
+  children,
+  markerKey,
+}: LazyPopupMarkerProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const markerRef = useRef<LeafletMarker>(null);
+
+  const handlePopupOpen = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const handlePopupClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  return (
+    <Marker
+      key={markerKey}
+      position={position}
+      icon={icon}
+      ref={markerRef}
+      eventHandlers={{
+        popupopen: handlePopupOpen,
+        popupclose: handlePopupClose,
+      }}
+    >
+      <Popup
+        maxWidth={popupProps.maxWidth ?? 260}
+        minWidth={popupProps.minWidth ?? 240}
+        autoPan={popupProps.autoPan ?? true}
+        autoPanPadding={popupProps.autoPanPadding ?? [20, 20]}
+        className={popupProps.className}
+      >
+        {isOpen ? children : <div style={{ width: 240, height: 80 }} />}
+      </Popup>
+    </Marker>
+  );
+};
+
+export default LazyPopupMarker;

--- a/apps/web/src/pages/Tasks/components/Map/index.ts
+++ b/apps/web/src/pages/Tasks/components/Map/index.ts
@@ -1,5 +1,6 @@
+export { default as MapMarkers } from './MapMarkers';
 export { default as MapController } from './MapController';
 export { default as LocationPicker } from './LocationPicker';
-export { default as MapMarkers } from './MapMarkers';
 export { default as JobMapPopup } from './JobMapPopup';
 export { default as OfferingMapPopup } from './OfferingMapPopup';
+export { default as LazyPopupMarker } from './LazyPopupMarker';


### PR DESCRIPTION
## Problem

Every map marker renders its full popup DOM (`JobMapPopup` / `OfferingMapPopup`) on mount — even though users only ever click 1-2 markers. With 50+ tasks on the map, this creates hundreds of unnecessary DOM nodes at page load, slowing down initial render and wasting memory.

Also, `getJobPriceIcon()` and `getBoostedOfferingIcon()` create new `L.divIcon` objects on every render, even when the same budget/category combo has been seen before.

## Solution

### 1. `LazyPopupMarker` component (new)
A wrapper around `<Marker>` + `<Popup>` that:
- Renders the marker with just an icon (cheap — only coordinates + a small HTML div)
- Listens for Leaflet's `popupopen` event → sets `isOpen=true` → React mounts the popup children
- On `popupclose` → sets `isOpen=false` → children unmount, freeing memory
- Shows a lightweight placeholder (240×80 div) while closed so Leaflet can size the popup

### 2. Icon caching
- `getCachedJobIcon(budget, isUrgent)` — caches by `"budget-isUrgent"` key
- `getCachedOfferingIcon(category)` — caches by category string
- Same budget/urgency combo reuses the same `L.DivIcon` instance across renders

### 3. Static popup props
- Moved popup config objects (`maxWidth`, `minWidth`, etc.) to module-level constants to avoid re-creating objects on every render

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Popup DOM nodes at load | N × full popup | 0 (mounted on click) |
| Icon objects created | N per render | 1 per unique budget/urgency |
| Memory on idle | All popups in DOM | Only marker pins |

## Files changed
- `LazyPopupMarker.tsx` — **new** component
- `MapMarkers.tsx` — uses `LazyPopupMarker`, adds icon caching
- `index.ts` — exports `LazyPopupMarker`

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/144?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->