### PR TITLE
perf: mobile map — icon caching, memoized cards, virtualized list

### DIFF
--- a/apps/web/src/components/MobileTasksView/components/MobileJobCard.tsx
+++ b/apps/web/src/components/MobileTasksView/components/MobileJobCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { Task } from '@marketplace/shared';
 import { calculateDistance, formatDistance } from '../utils/distance';
 import { formatTimeAgo } from '../utils/formatting';
@@ -24,14 +25,19 @@ interface MobileJobCardProps {
 }
 
 /**
- * Compact job card for the task list
+ * Compact job card for the task list.
+ *
+ * Wrapped in React.memo so it only re-renders when its own props change.
+ * This is critical because the parent (MobileTasksView) re-renders on
+ * every state change (sheet drag, search input, selected task change),
+ * but individual cards don't need to update unless their data changed.
  */
-const MobileJobCard = ({
+const MobileJobCard = memo(function MobileJobCard({
   task,
   userLocation,
   onClick,
   isSelected,
-}: MobileJobCardProps) => {
+}: MobileJobCardProps) {
   const distance = calculateDistance(
     userLocation.lat,
     userLocation.lng,
@@ -93,6 +99,7 @@ const MobileJobCard = ({
                 src={task.creator_avatar} 
                 alt={task.creator_name || 'User'} 
                 className="w-full h-full object-cover"
+                loading="lazy"
               />
             ) : (
               <span>{(task.creator_name || 'U')[0].toUpperCase()}</span>
@@ -152,6 +159,20 @@ const MobileJobCard = ({
       </div>
     </div>
   );
-};
+}, (prevProps, nextProps) => {
+  // Custom comparator: only re-render if something the card displays changed
+  return (
+    prevProps.task.id === nextProps.task.id &&
+    prevProps.isSelected === nextProps.isSelected &&
+    prevProps.userLocation.lat === nextProps.userLocation.lat &&
+    prevProps.userLocation.lng === nextProps.userLocation.lng &&
+    prevProps.task.title === nextProps.task.title &&
+    prevProps.task.budget === nextProps.task.budget &&
+    prevProps.task.reward === nextProps.task.reward &&
+    prevProps.task.is_urgent === nextProps.task.is_urgent &&
+    prevProps.task.creator_name === nextProps.task.creator_name &&
+    prevProps.task.creator_rating === nextProps.task.creator_rating
+  );
+});
 
 export default MobileJobCard;

--- a/apps/web/src/components/MobileTasksView/components/VirtualizedJobList.tsx
+++ b/apps/web/src/components/MobileTasksView/components/VirtualizedJobList.tsx
@@ -1,0 +1,137 @@
+import { useRef, useState, useEffect, useCallback, memo } from 'react';
+import { Task } from '@marketplace/shared';
+import MobileJobCard from './MobileJobCard';
+
+interface VirtualizedJobListProps {
+  tasks: Task[];
+  userLocation: { lat: number; lng: number };
+  selectedTaskId: number | null;
+  onJobSelect: (task: Task) => void;
+}
+
+/**
+ * Estimated height of a single MobileJobCard in pixels.
+ * Used for initial placeholder sizing. Doesn't need to be exact —
+ * IntersectionObserver handles the actual visibility detection.
+ */
+const CARD_HEIGHT_ESTIMATE = 88;
+
+/**
+ * How many cards above/below the viewport to keep rendered.
+ * Higher = smoother scrolling (fewer pop-ins), more DOM nodes.
+ * 5 is a good balance for mobile — ~440px buffer each direction.
+ */
+const BUFFER_COUNT = 5;
+
+/**
+ * Lightweight virtualized list for the mobile bottom sheet.
+ *
+ * Instead of rendering all 50+ MobileJobCard components at once,
+ * this only renders cards that are near the visible scroll area.
+ * Cards outside the viewport are replaced with empty divs of the
+ * estimated height to maintain scroll position and scrollbar size.
+ *
+ * Uses IntersectionObserver (GPU-accelerated, no scroll listener)
+ * to track which range of cards is visible.
+ */
+const VirtualizedJobList = memo(function VirtualizedJobList({
+  tasks,
+  userLocation,
+  selectedTaskId,
+  onJobSelect,
+}: VirtualizedJobListProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [visibleRange, setVisibleRange] = useState({ start: 0, end: 15 });
+
+  // Sentinel refs: we place invisible sentinels at intervals and observe them
+  const sentinelRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+
+  const setSentinelRef = useCallback((index: number, el: HTMLDivElement | null) => {
+    if (el) {
+      sentinelRefs.current.set(index, el);
+    } else {
+      sentinelRefs.current.delete(index);
+    }
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // Find the range of visible sentinels
+        let minVisible = Infinity;
+        let maxVisible = -Infinity;
+
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const idx = parseInt(entry.target.getAttribute('data-sentinel-index') || '0', 10);
+            minVisible = Math.min(minVisible, idx);
+            maxVisible = Math.max(maxVisible, idx);
+          }
+        });
+
+        if (minVisible !== Infinity) {
+          setVisibleRange((prev) => {
+            const newStart = Math.max(0, minVisible - BUFFER_COUNT);
+            const newEnd = Math.min(tasks.length, maxVisible + BUFFER_COUNT + 1);
+            // Only update if range actually changed (avoids re-renders)
+            if (prev.start === newStart && prev.end === newEnd) return prev;
+            return { start: newStart, end: newEnd };
+          });
+        }
+      },
+      {
+        root: container,
+        rootMargin: `${BUFFER_COUNT * CARD_HEIGHT_ESTIMATE}px 0px`,
+        threshold: 0,
+      }
+    );
+
+    // Observe all current sentinels
+    sentinelRefs.current.forEach((el) => observer.observe(el));
+
+    return () => observer.disconnect();
+  }, [tasks.length]);
+
+  // Reset visible range when tasks change (e.g. new filter)
+  useEffect(() => {
+    setVisibleRange({ start: 0, end: Math.min(15, tasks.length) });
+  }, [tasks]);
+
+  if (tasks.length === 0) return null;
+
+  return (
+    <div ref={containerRef} className="h-full overflow-y-auto overscroll-contain" style={{ touchAction: 'pan-y' }}>
+      {tasks.map((task, index) => {
+        const isInRange = index >= visibleRange.start && index < visibleRange.end;
+
+        return (
+          <div key={task.id}>
+            {/* Sentinel div — always rendered, near-zero cost */}
+            <div
+              ref={(el) => setSentinelRef(index, el)}
+              data-sentinel-index={index}
+              style={{ height: 0, overflow: 'hidden' }}
+            />
+            {isInRange ? (
+              <MobileJobCard
+                task={task}
+                userLocation={userLocation}
+                onClick={() => onJobSelect(task)}
+                isSelected={selectedTaskId === task.id}
+              />
+            ) : (
+              // Placeholder — preserves scroll height
+              <div style={{ height: CARD_HEIGHT_ESTIMATE }} />
+            )}
+          </div>
+        );
+      })}
+      <div className="h-4" />
+    </div>
+  );
+});
+
+export default VirtualizedJobList;

--- a/apps/web/src/components/MobileTasksView/components/index.ts
+++ b/apps/web/src/components/MobileTasksView/components/index.ts
@@ -4,3 +4,4 @@ export { default as JobPreviewCard } from './JobPreviewCard';
 export { default as CreateChoiceModal } from './CreateChoiceModal';
 export { default as FilterSheet } from './FilterSheet';
 export { default as FloatingSearchBar } from './FloatingSearchBar';
+export { default as VirtualizedJobList } from './VirtualizedJobList';


### PR DESCRIPTION
## Problem

The mobile view (`MobileTasksView`) has three compounding performance issues:

1. **Icon recreation** — `getJobPriceIcon()` creates a new `L.divIcon` on every render for every marker. With 50 tasks, that's 50 new icon objects every time the component re-renders (sheet drag, search input, task selection).

2. **Full list rendering** — The bottom sheet renders all `MobileJobCard` components at once. Each card includes distance calculation, avatar, star rating, and multiple conditional layouts. With 50+ tasks, this means 50+ cards mounted in the DOM on initial load.

3. **Cascading re-renders** — Every state change (dragging the sheet, typing in search, selecting a marker) causes the entire 400-line component to re-render, including all markers and all list cards, even when only one thing changed.

## Solution

### 1. Icon caching (`markers.ts`)
- Two caches: one for normal state, one for selected state (different iconSize/anchor)
- Cache key: `"budget-isUrgent"` — same combo reuses the same `L.divIcon` instance
- Identical visual output, zero functional change

### 2. Memoized job cards (`MobileJobCard.tsx`)
- Wrapped in `React.memo` with a custom comparator
- Only re-renders when its own data changes (task id, title, budget, selection, location)
- Added `loading="lazy"` to creator avatar images

### 3. Virtualized job list (`VirtualizedJobList.tsx`) — new component
- Uses `IntersectionObserver` (GPU-accelerated, no scroll event listener)
- Only renders cards visible in the scroll viewport + 5 cards buffer each direction
- Off-screen cards are replaced with height-preserving placeholder divs
- Resets to top-15 when task list changes (filter/search)

### 4. Memoized marker layer (`MobileTasksView.tsx`)
- Extracted `TaskMarkers` as a `memo` component — only re-renders when `tasksWithOffsets` or `selectedTaskId` changes
- Wrapped all event handlers in `useCallback` so child components get stable references
- Replaced inline `filteredTasks.map` with `VirtualizedJobList`

## What stays the same
- All visual behavior — cards look identical, markers look identical
- Bottom sheet drag mechanics — untouched
- Deep link handling — untouched
- Search/filter logic — untouched (runs in `useTasksData` hook)
- Data fetching — no backend changes

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Icon objects on re-render | N new per render | 1 per unique budget/urgency (cached) |
| Card DOM nodes at load | All N tasks | ~15 visible + 10 buffer |
| Re-renders on sheet drag | All cards + markers | 0 cards, 0 markers |
| Re-renders on task select | All cards + all markers | 1 card (old) + 1 card (new) + markers |

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/145?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->