### PR TITLE
perf(mobile): smoother map — mobile-specific tile config, throttled layout, animation pausing

### DIFF
--- a/apps/web/src/components/MobileTasksView/components/MapController.tsx
+++ b/apps/web/src/components/MobileTasksView/components/MapController.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { useMap } from 'react-leaflet';
 import { Task } from '@marketplace/shared';
 import { useMobileMapStore } from '../stores';
@@ -42,6 +42,7 @@ const MapController = ({
   const hasFitBothPoints = useRef(false);
   const hasHandledSelectedTask = useRef(false);
   const prevRadius = useRef(radius);
+  const invalidatePending = useRef(false);
 
   // --- Persist viewport on every map move/zoom ---
   useEffect(() => {
@@ -59,6 +60,30 @@ const MapController = ({
       map.off('zoomend', saveViewport);
     };
   }, [map, store]);
+
+  // --- Pause CSS animations during map interaction ───────
+  // Adds .map-interacting to the map container on movestart,
+  // removes it on moveend. This pauses all infinite keyframe
+  // animations (pulse, urgentPulse) so the browser compositor
+  // can focus entirely on repositioning tiles and markers.
+  useEffect(() => {
+    const container = map.getContainer();
+
+    const onMoveStart = () => {
+      container.classList.add('map-interacting');
+    };
+    const onMoveEnd = () => {
+      container.classList.remove('map-interacting');
+    };
+
+    map.on('movestart', onMoveStart);
+    map.on('moveend', onMoveEnd);
+    return () => {
+      map.off('movestart', onMoveStart);
+      map.off('moveend', onMoveEnd);
+      container.classList.remove('map-interacting');
+    };
+  }, [map]);
 
   // --- Restore viewport on mount (if persisted) ---
   useEffect(() => {
@@ -100,13 +125,28 @@ const MapController = ({
     setTimeout(() => { isSettingView.current = false; }, 700);
   }, [fitBothPoints, map]);
 
-  // Invalidate map size when menu closes or sheet position changes
+  // --- Throttled invalidateSize ──────────────────────────
+  // Coalesces multiple invalidateSize calls into one per frame.
+  // Before: every sheet position change, resize, focus, visibility
+  // change would each trigger a full layout recalc.
+  // After: batched into a single requestAnimationFrame.
+  const throttledInvalidateSize = useCallback(() => {
+    if (invalidatePending.current) return;
+    invalidatePending.current = true;
+    requestAnimationFrame(() => {
+      map.invalidateSize({ pan: false });
+      invalidatePending.current = false;
+    });
+  }, [map]);
+
+  // Invalidate map size when menu closes (NOT on sheet position change —
+  // sheet drags were triggering this dozens of times per second)
   useEffect(() => {
     const timer = setTimeout(() => {
-      map.invalidateSize({ pan: false });
+      throttledInvalidateSize();
     }, 350);
     return () => clearTimeout(timer);
-  }, [isMenuOpen, sheetPosition, map]);
+  }, [isMenuOpen, throttledInvalidateSize]);
 
   // Handle radius changes and recenter.
   useEffect(() => {
@@ -165,23 +205,23 @@ const MapController = ({
   // Invalidate size on mount
   useEffect(() => {
     const timer = setTimeout(() => {
-      map.invalidateSize();
+      throttledInvalidateSize();
     }, 100);
     return () => clearTimeout(timer);
-  }, [map]);
+  }, [throttledInvalidateSize]);
 
   // Fix map tiles on back-navigation
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
         setTimeout(() => {
-          map.invalidateSize({ pan: false });
+          throttledInvalidateSize();
         }, 150);
       }
     };
 
     const handleResize = () => {
-      map.invalidateSize({ pan: false });
+      throttledInvalidateSize();
     };
 
     document.addEventListener('visibilitychange', handleVisibilityChange);
@@ -193,7 +233,7 @@ const MapController = ({
       window.removeEventListener('resize', handleResize);
       window.removeEventListener('focus', handleVisibilityChange);
     };
-  }, [map]);
+  }, [throttledInvalidateSize]);
 
   return null;
 };

--- a/apps/web/src/components/MobileTasksView/styles.ts
+++ b/apps/web/src/components/MobileTasksView/styles.ts
@@ -48,4 +48,28 @@ export const mobileTasksStyles = `
   .urgent-marker {
     z-index: 500 !important;
   }
+
+  /* ── Mobile map GPU acceleration ────────────────────────── */
+  .mobile-map-container .leaflet-container {
+    will-change: transform;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
+  }
+  .mobile-map-container .leaflet-tile-pane {
+    will-change: transform;
+  }
+  .mobile-map-container .leaflet-marker-pane {
+    will-change: transform;
+  }
+
+  /* ── Pause marker animations during map interaction ────── */
+  /* Applied via JS on movestart, removed on moveend.        */
+  /* Frees the compositor from running infinite keyframes     */
+  /* while Leaflet is repositioning tiles + markers.          */
+  .map-interacting .leaflet-marker-icon * {
+    animation-play-state: paused !important;
+  }
+  .map-interacting .user-location-icon * {
+    animation-play-state: paused !important;
+  }
 `;


### PR DESCRIPTION
## Problem

The mobile map feels sluggish during zoom and pan. The previous PRs optimized React rendering (good for list/cards), but the actual frame drops come from Leaflet itself:

1. **Fractional zoom (`zoomSnap: 0.25`)** — shared config creates 4x more intermediate zoom steps during pinch-to-zoom. Each step triggers tile reloads + marker repositioning.
2. **Massive tile buffer (`keepBuffer: 8`)** — preloads 8 rows of tiles outside the viewport. On mobile with limited bandwidth and memory, the browser is downloading and decoding tiles that aren't even visible.
3. **`invalidateSize` spam** — triggered on every sheet position change (during drag = dozens per second), on mount, on resize, on visibility, on focus. Each call forces Leaflet to recalculate the entire map layout.
4. **Infinite CSS animations during map interaction** — `pulse` and `urgentPulse` keyframes run on every urgent marker + the user location dot. During zoom/pan, the browser compositor is simultaneously running these animations AND repositioning tiles/markers.

## Solution (scoped to MobileTasksView only — desktop untouched)

### Mobile-specific map config (`MobileTasksView.tsx`)
- `zoomSnap: 1` / `zoomDelta: 1` — whole-number zoom, snappy pinch feel
- `keepBuffer: 3` — preload 3 rows instead of 8, lighter on bandwidth + memory
- `preferCanvas: true` — hint for Leaflet to use canvas renderer where applicable
- Uses `MOBILE_MAP_PROPS` and `MOBILE_TILE_PERF` instead of shared constants
- Added `mobile-map-container` CSS class for GPU acceleration hints

### Throttled invalidateSize (`MapController.tsx`)
- Replaced all direct `map.invalidateSize()` calls with `throttledInvalidateSize()` that batches into a single `requestAnimationFrame`
- **Removed `sheetPosition` from the invalidateSize trigger** — this was the worst offender, firing during every drag frame
- Kept the `isMenuOpen` trigger (fires once when menu closes, not continuously)

### Animation pausing during interaction (`MapController.tsx` + `styles.ts`)
- On `movestart`: adds `.map-interacting` class to map container
- On `moveend`: removes it
- CSS rule: `.map-interacting .leaflet-marker-icon * { animation-play-state: paused !important }`
- Frees the compositor to focus on tile/marker repositioning during zoom/pan

### GPU acceleration hints (`styles.ts`)
- `will-change: transform` on `.leaflet-container`, `.leaflet-tile-pane`, `.leaflet-marker-pane`
- `transform: translateZ(0)` to force GPU compositing layer
- Scoped to `.mobile-map-container` so desktop is unaffected

## What stays the same
- Desktop map config — still uses shared `MAP_CONTAINER_PROPS` / `MAP_TILE_PERF`
- All map behavior — recenter, radius zoom, deep links, task selection pan
- Visual appearance — same tiles, same markers, same animations (just paused during interaction)
- Bottom sheet mechanics — untouched

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/146?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->