### PR TITLE
fix: remove job list virtualization causing disappearing cards

### DIFF
--- a/apps/web/src/components/MobileTasksView/components/VirtualizedJobList.tsx
+++ b/apps/web/src/components/MobileTasksView/components/VirtualizedJobList.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, useCallback, memo } from 'react';
+import { memo } from 'react';
 import { Task } from '@marketplace/shared';
 import MobileJobCard from './MobileJobCard';
 
@@ -10,33 +10,12 @@ interface VirtualizedJobListProps {
 }
 
 /**
- * Estimated height of a single MobileJobCard in pixels.
- * Used for initial placeholder sizing. Doesn't need to be exact —
- * IntersectionObserver handles the actual visibility detection.
- */
-const CARD_HEIGHT_ESTIMATE = 88;
-
-/**
- * How many cards above/below the viewport to keep rendered.
- * Higher = smoother scrolling (fewer pop-ins), more DOM nodes.
- * 5 is a good balance for mobile — ~440px buffer each direction.
- */
-const BUFFER_COUNT = 5;
-
-/**
- * Lightweight virtualized list for the mobile bottom sheet.
+ * Job list for the mobile bottom sheet.
  *
- * Instead of rendering all 50+ MobileJobCard components at once,
- * this only renders cards that are near the visible scroll area.
- * Cards outside the viewport are replaced with empty divs of the
- * estimated height to maintain scroll position and scrollbar size.
- *
- * Uses IntersectionObserver (GPU-accelerated, no scroll listener)
- * to track which range of cards is visible.
- *
- * A ResizeObserver on the scroll container detects when the bottom
- * sheet changes size (collapsed → half → full) and re-initializes
- * the IntersectionObserver with fresh root dimensions.
+ * Renders all cards directly — MobileJobCard is already wrapped in
+ * React.memo with a custom comparator, so re-renders only happen
+ * when individual card data changes. At typical list sizes (20-50),
+ * this is more reliable and equally performant vs. virtualization.
  */
 const VirtualizedJobList = memo(function VirtualizedJobList({
   tasks,
@@ -44,117 +23,19 @@ const VirtualizedJobList = memo(function VirtualizedJobList({
   selectedTaskId,
   onJobSelect,
 }: VirtualizedJobListProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [visibleRange, setVisibleRange] = useState({ start: 0, end: 15 });
-
-  // Tracks container resize events to force IntersectionObserver re-init
-  const [resizeGeneration, setResizeGeneration] = useState(0);
-
-  // Sentinel refs: we place invisible sentinels at intervals and observe them
-  const sentinelRefs = useRef<Map<number, HTMLDivElement>>(new Map());
-
-  const setSentinelRef = useCallback((index: number, el: HTMLDivElement | null) => {
-    if (el) {
-      sentinelRefs.current.set(index, el);
-    } else {
-      sentinelRefs.current.delete(index);
-    }
-  }, []);
-
-  // ResizeObserver: detect when the scroll container changes size
-  // (e.g. bottom sheet expanding/collapsing, orientation change, keyboard)
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const resizeObserver = new ResizeObserver(() => {
-      // Bump generation to force IntersectionObserver re-creation
-      setResizeGeneration((g) => g + 1);
-      // Reset visible range so cards re-appear immediately
-      setVisibleRange({ start: 0, end: Math.min(15, tasks.length) });
-    });
-
-    resizeObserver.observe(container);
-    return () => resizeObserver.disconnect();
-  }, [tasks.length]);
-
-  // IntersectionObserver: track which cards are near the viewport
-  // Re-initializes when tasks change OR when the container resizes
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        // Find the range of visible sentinels
-        let minVisible = Infinity;
-        let maxVisible = -Infinity;
-
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            const idx = parseInt(entry.target.getAttribute('data-sentinel-index') || '0', 10);
-            minVisible = Math.min(minVisible, idx);
-            maxVisible = Math.max(maxVisible, idx);
-          }
-        });
-
-        if (minVisible !== Infinity) {
-          setVisibleRange((prev) => {
-            const newStart = Math.max(0, minVisible - BUFFER_COUNT);
-            const newEnd = Math.min(tasks.length, maxVisible + BUFFER_COUNT + 1);
-            // Only update if range actually changed (avoids re-renders)
-            if (prev.start === newStart && prev.end === newEnd) return prev;
-            return { start: newStart, end: newEnd };
-          });
-        }
-      },
-      {
-        root: container,
-        rootMargin: `${BUFFER_COUNT * CARD_HEIGHT_ESTIMATE}px 0px`,
-        threshold: 0,
-      }
-    );
-
-    // Observe all current sentinels
-    sentinelRefs.current.forEach((el) => observer.observe(el));
-
-    return () => observer.disconnect();
-  }, [tasks.length, resizeGeneration]);
-
-  // Reset visible range when tasks change (e.g. new filter)
-  useEffect(() => {
-    setVisibleRange({ start: 0, end: Math.min(15, tasks.length) });
-  }, [tasks]);
-
   if (tasks.length === 0) return null;
 
   return (
-    <div ref={containerRef} className="h-full overflow-y-auto overscroll-contain" style={{ touchAction: 'pan-y' }}>
-      {tasks.map((task, index) => {
-        const isInRange = index >= visibleRange.start && index < visibleRange.end;
-
-        return (
-          <div key={task.id}>
-            {/* Sentinel div — always rendered, near-zero cost */}
-            <div
-              ref={(el) => setSentinelRef(index, el)}
-              data-sentinel-index={index}
-              style={{ height: 0, overflow: 'hidden' }}
-            />
-            {isInRange ? (
-              <MobileJobCard
-                task={task}
-                userLocation={userLocation}
-                onClick={() => onJobSelect(task)}
-                isSelected={selectedTaskId === task.id}
-              />
-            ) : (
-              // Placeholder — preserves scroll height
-              <div style={{ height: CARD_HEIGHT_ESTIMATE }} />
-            )}
-          </div>
-        );
-      })}
+    <div className="h-full overflow-y-auto overscroll-contain" style={{ touchAction: 'pan-y' }}>
+      {tasks.map((task) => (
+        <MobileJobCard
+          key={task.id}
+          task={task}
+          userLocation={userLocation}
+          onClick={() => onJobSelect(task)}
+          isSelected={selectedTaskId === task.id}
+        />
+      ))}
       <div className="h-4" />
     </div>
   );


### PR DESCRIPTION
## Problem

The IntersectionObserver-based virtualization in `VirtualizedJobList` was causing job cards to disappear when scrolling the bottom sheet. The observer callback only receives partial entry batches per fire, leading to miscalculated visible ranges that replace real cards with empty placeholder divs.

The ResizeObserver patch from PR #147 made it worse by constantly re-initializing the observer during any scroll interaction.

## Fix

Removed the virtualization entirely and render all `MobileJobCard` components directly. Each card is already wrapped in `React.memo` with a custom comparator, so re-renders only happen when individual card data changes.

At typical list sizes (20-50 jobs), this is:
- **More reliable** — no observer edge cases, no disappearing cards
- **Equally performant** — 20-50 memo'd components is trivial for any modern phone
- **Simpler** — went from 140 lines to 40 lines

## What changed

- `VirtualizedJobList.tsx`: Removed `IntersectionObserver`, `ResizeObserver`, sentinel refs, visible range tracking, placeholder divs. Now just maps over tasks and renders `MobileJobCard` for each.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/148?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->