### PR TITLE
fix(ui): remove redundant Profile link from task detail page

### DIFF
--- a/apps/web/src/pages/TaskDetail/TaskDetail.tsx
+++ b/apps/web/src/pages/TaskDetail/TaskDetail.tsx
@@ -355,14 +355,6 @@ const TaskDetail = () => {
                   </svg>
                 </button>
               )}
-              {!isCreator && (
-                <Link
-                  to={`/users/${task.creator_id}`}
-                  className="text-xs md:text-sm text-blue-600 dark:text-blue-400 font-medium hover:text-blue-700 dark:hover:text-blue-300 flex-shrink-0"
-                >
-                  {t('taskDetail.profile')}
-                </Link>
-              )}
               {isCreator && canEdit && (
                 <Link
                   to={`/tasks/${task.id}/edit`}


### PR DESCRIPTION
## Problem

On the task detail page, next to the creator's name there were two actions:
1. 💬 Message bubble — opens messages with that person ✅ (keep)
2. "Profile" text link — navigates to the creator's profile ❌ (redundant)

The creator's **name** and **avatar** are already clickable links to their profile, so the separate "Profile" link was unnecessary clutter.

## Fix

Removed the `{!isCreator && <Link>Profile</Link>}` block from the profile row in `TaskDetail.tsx`.

Kept:
- Message bubble button (for non-creators)
- Edit link (for the task creator when task is open)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/152?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->