### PR TITLE
fix: images display, ImagePicker dark mode, map touch & title overflow

### DIFF
--- a/apps/web/src/components/ImageGallery.tsx
+++ b/apps/web/src/components/ImageGallery.tsx
@@ -1,0 +1,198 @@
+import { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface ImageGalleryProps {
+  images: string[];
+  alt?: string;
+}
+
+/**
+ * Read-only image gallery for detail pages (TaskDetail, OfferingDetail).
+ * Shows horizontal scroll strip with tap-to-expand fullscreen lightbox.
+ */
+const ImageGallery = ({ images, alt = 'Image' }: ImageGalleryProps) => {
+  const { t } = useTranslation();
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+
+  const openLightbox = useCallback((index: number) => {
+    setLightboxIndex(index);
+    document.body.style.overflow = 'hidden';
+  }, []);
+
+  const closeLightbox = useCallback(() => {
+    setLightboxIndex(null);
+    document.body.style.overflow = '';
+  }, []);
+
+  const goNext = useCallback(() => {
+    setLightboxIndex((prev) => (prev !== null && prev < images.length - 1 ? prev + 1 : prev));
+  }, [images.length]);
+
+  const goPrev = useCallback(() => {
+    setLightboxIndex((prev) => (prev !== null && prev > 0 ? prev - 1 : prev));
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') closeLightbox();
+      if (e.key === 'ArrowRight') goNext();
+      if (e.key === 'ArrowLeft') goPrev();
+    },
+    [closeLightbox, goNext, goPrev]
+  );
+
+  if (!images || images.length === 0) return null;
+
+  if (images.length === 1) {
+    return (
+      <>
+        <div className="cursor-pointer" onClick={() => openLightbox(0)}>
+          <img
+            src={images[0]}
+            alt={alt}
+            className="w-full h-48 md:h-64 object-cover rounded-lg border border-gray-200 dark:border-gray-700"
+            loading="lazy"
+          />
+        </div>
+        {lightboxIndex !== null && (
+          <Lightbox
+            images={images}
+            index={lightboxIndex}
+            onClose={closeLightbox}
+            onNext={goNext}
+            onPrev={goPrev}
+            onKeyDown={handleKeyDown}
+          />
+        )}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex gap-2 overflow-x-auto pb-2 -mx-1 px-1 scrollbar-hide">
+        {images.map((url, i) => (
+          <div
+            key={i}
+            className="flex-shrink-0 cursor-pointer relative"
+            onClick={() => openLightbox(i)}
+          >
+            <img
+              src={url}
+              alt={`${alt} ${i + 1}`}
+              className="h-32 md:h-44 w-auto min-w-[8rem] md:min-w-[10rem] object-cover rounded-lg border border-gray-200 dark:border-gray-700"
+              loading="lazy"
+            />
+            {i === 0 && images.length > 1 && (
+              <span className="absolute bottom-1.5 right-1.5 bg-black/60 text-white text-xs font-medium px-1.5 py-0.5 rounded-md">
+                1/{images.length}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {lightboxIndex !== null && (
+        <Lightbox
+          images={images}
+          index={lightboxIndex}
+          onClose={closeLightbox}
+          onNext={goNext}
+          onPrev={goPrev}
+          onKeyDown={handleKeyDown}
+        />
+      )}
+    </>
+  );
+};
+
+/* ─── Fullscreen lightbox ─── */
+
+interface LightboxProps {
+  images: string[];
+  index: number;
+  onClose: () => void;
+  onNext: () => void;
+  onPrev: () => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+}
+
+const Lightbox = ({ images, index, onClose, onNext, onPrev, onKeyDown }: LightboxProps) => {
+  const [touchStart, setTouchStart] = useState<number | null>(null);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setTouchStart(e.touches[0].clientX);
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStart === null) return;
+    const diff = e.changedTouches[0].clientX - touchStart;
+    if (Math.abs(diff) > 50) {
+      if (diff > 0) onPrev();
+      else onNext();
+    }
+    setTouchStart(null);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] bg-black/95 flex items-center justify-center"
+      onClick={onClose}
+      onKeyDown={onKeyDown}
+      tabIndex={0}
+      role="dialog"
+      aria-modal="true"
+      ref={(el) => el?.focus()}
+    >
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 z-10 w-10 h-10 flex items-center justify-center rounded-full bg-white/10 hover:bg-white/20 text-white transition-colors"
+        aria-label="Close"
+      >
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+
+      <div className="absolute top-4 left-4 z-10 text-white/80 text-sm font-medium">
+        {index + 1} / {images.length}
+      </div>
+
+      {index > 0 && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onPrev(); }}
+          className="absolute left-2 md:left-4 z-10 w-10 h-10 flex items-center justify-center rounded-full bg-white/10 hover:bg-white/20 text-white transition-colors"
+          aria-label="Previous"
+        >
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+      )}
+
+      <img
+        src={images[index]}
+        alt={`Image ${index + 1}`}
+        className="max-h-[85vh] max-w-[95vw] object-contain select-none"
+        onClick={(e) => e.stopPropagation()}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+        draggable={false}
+      />
+
+      {index < images.length - 1 && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onNext(); }}
+          className="absolute right-2 md:right-4 z-10 w-10 h-10 flex items-center justify-center rounded-full bg-white/10 hover:bg-white/20 text-white transition-colors"
+          aria-label="Next"
+        >
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ImageGallery;

--- a/apps/web/src/components/ImagePicker.tsx
+++ b/apps/web/src/components/ImagePicker.tsx
@@ -30,7 +30,7 @@ const ImagePicker = ({
       const fileArray = Array.from(files);
       const validFiles = fileArray.filter((file) => {
         if (!file.type.startsWith('image/')) return false;
-        if (file.size > 10 * 1024 * 1024) return false; // 10MB limit
+        if (file.size > 10 * 1024 * 1024) return false;
         return true;
       });
 
@@ -48,7 +48,6 @@ const ImagePicker = ({
     if (e.target.files) {
       validateAndAddFiles(e.target.files);
     }
-    // Reset so the same file can be re-selected
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
@@ -74,12 +73,11 @@ const ImagePicker = ({
   return (
     <div>
       {label && (
-        <label className="block text-sm font-medium text-gray-700 mb-1">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
           {label}
         </label>
       )}
 
-      {/* Existing image previews */}
       {existingUrls.length > 0 && (
         <div className="flex flex-wrap gap-2 mb-2">
           {existingUrls.map((url, i) => (
@@ -87,7 +85,7 @@ const ImagePicker = ({
               <img
                 src={url}
                 alt={`Existing ${i + 1}`}
-                className="w-full h-full object-cover rounded-lg border border-gray-200"
+                className="w-full h-full object-cover rounded-lg border border-gray-200 dark:border-gray-700"
               />
               {onRemoveExisting && (
                 <button
@@ -103,7 +101,6 @@ const ImagePicker = ({
         </div>
       )}
 
-      {/* New image previews */}
       {images.length > 0 && (
         <div className="flex flex-wrap gap-2 mb-2">
           {images.map((file, i) => (
@@ -111,7 +108,7 @@ const ImagePicker = ({
               <img
                 src={URL.createObjectURL(file)}
                 alt={`New ${i + 1}`}
-                className="w-full h-full object-cover rounded-lg border border-gray-200"
+                className="w-full h-full object-cover rounded-lg border border-gray-200 dark:border-gray-700"
               />
               <button
                 type="button"
@@ -125,7 +122,6 @@ const ImagePicker = ({
         </div>
       )}
 
-      {/* Drop zone / Add button */}
       {canAddMore && (
         <div
           onClick={() => fileInputRef.current?.click()}
@@ -134,14 +130,14 @@ const ImagePicker = ({
           onDragLeave={handleDragLeave}
           className={`border-2 border-dashed rounded-lg p-4 text-center cursor-pointer transition-colors ${
             dragOver
-              ? 'border-blue-500 bg-blue-50'
-              : 'border-gray-300 hover:border-blue-400 hover:bg-gray-50'
+              ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
+              : 'border-gray-300 dark:border-gray-600 hover:border-blue-400 dark:hover:border-blue-500 hover:bg-gray-50 dark:hover:bg-gray-800'
           }`}
         >
-          <div className="text-gray-500 text-sm">
+          <div className="text-gray-500 dark:text-gray-400 text-sm">
             <span className="text-2xl block mb-1">📷</span>
             <p>{t('imagePicker.dropOrClick', 'Drop images here or click to browse')}</p>
-            <p className="text-xs text-gray-400 mt-1">
+            <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
               {t('imagePicker.limit', '{{current}} / {{max}} images (max 10MB each)', {
                 current: totalImages,
                 max: maxImages,

--- a/apps/web/src/pages/CreateOffering/CreateOffering.tsx
+++ b/apps/web/src/pages/CreateOffering/CreateOffering.tsx
@@ -11,6 +11,7 @@ import {
   FormTips,
   SuccessModal,
 } from './components';
+import ImagePicker from '../../components/ImagePicker';
 
 const CreateOffering = () => {
   const { t } = useTranslation();
@@ -73,6 +74,13 @@ const CreateOffering = () => {
                 className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-amber-500 focus:border-transparent text-base sm:text-sm placeholder:text-gray-400 dark:placeholder:text-gray-500"
               />
             </div>
+
+            <ImagePicker
+              images={formData.images}
+              onChange={(imgs) => updateField('images', imgs)}
+              maxImages={5}
+              label={`${t('createOffering.photos', 'Photos')} (${t('common.optional', 'Optional')})`}
+            />
 
             <PriceTypeSelector
               value={formData.price_type}

--- a/apps/web/src/pages/OfferingDetail/OfferingDetail.tsx
+++ b/apps/web/src/pages/OfferingDetail/OfferingDetail.tsx
@@ -4,6 +4,7 @@ import { useOffering } from '../../api/hooks';
 import { useAuthStore } from '@marketplace/shared';
 import ShareButton from '../../components/ui/ShareButton';
 import SEOHead from '../../components/ui/SEOHead';
+import ImageGallery from '../../components/ImageGallery';
 import {
   OfferingHeader,
   OfferingProfileRow,
@@ -120,6 +121,13 @@ const OfferingDetail = () => {
               <p className="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed whitespace-pre-wrap">
                 {safe.safeDescription}
               </p>
+            </div>
+          )}
+
+          {/* Images */}
+          {(offering as any).images && (offering as any).images.length > 0 && (
+            <div className="px-4 pb-3 md:px-6 md:pb-5">
+              <ImageGallery images={(offering as any).images} alt={safe.safeTitle} />
             </div>
           )}
 

--- a/apps/web/src/pages/OfferingDetail/components/OfferingHeader.tsx
+++ b/apps/web/src/pages/OfferingDetail/components/OfferingHeader.tsx
@@ -40,7 +40,7 @@ const OfferingHeader = ({ categoryIcon, categoryLabel, priceDisplay, safePriceTy
           )}
         </div>
       </div>
-      <h1 className="text-base font-bold text-gray-900 dark:text-gray-100 leading-snug">{safeTitle}</h1>
+      <h1 className="text-base font-bold text-gray-900 dark:text-gray-100 leading-snug line-clamp-3">{safeTitle}</h1>
     </div>
   </>
 );

--- a/apps/web/src/pages/OfferingDetail/components/OfferingLocationMap.tsx
+++ b/apps/web/src/pages/OfferingDetail/components/OfferingLocationMap.tsx
@@ -39,6 +39,9 @@ const OfferingLocationMap = ({ latitude, longitude, safeTitle, safeLocation, ser
         style={{ height: '100%', width: '100%' }}
         scrollWheelZoom={false}
         zoomControl={false}
+        dragging={false}
+        doubleClickZoom={false}
+        touchZoom={false}
       >
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'

--- a/apps/web/src/pages/TaskDetail/TaskDetail.tsx
+++ b/apps/web/src/pages/TaskDetail/TaskDetail.tsx
@@ -23,6 +23,7 @@ import { useToastStore } from '@marketplace/shared';
 import { getCategoryLabel, getCategoryIcon } from '../../constants/categories';
 import SEOHead from '../../components/ui/SEOHead';
 import ShareButton from '../../components/ui/ShareButton';
+import ImageGallery from '../../components/ImageGallery';
 import { FEATURES } from '../../constants/featureFlags';
 import { formatTimeAgoLong } from '../Tasks/utils/taskHelpers';
 
@@ -297,7 +298,7 @@ const TaskDetail = () => {
               </div>
               <span className="text-xl font-black text-green-600 dark:text-green-400">€{budget}</span>
             </div>
-            <h1 className="text-base font-bold text-gray-900 dark:text-gray-100 leading-snug">{task.title}</h1>
+            <h1 className="text-base font-bold text-gray-900 dark:text-gray-100 leading-snug line-clamp-3">{task.title}</h1>
           </div>
 
           {/* Profile row */}
@@ -358,6 +359,13 @@ const TaskDetail = () => {
               {task.description}
             </p>
           </div>
+
+          {/* Images */}
+          {(task as any).images && (task as any).images.length > 0 && (
+            <div className="px-4 pb-3 md:px-6 md:pb-5">
+              <ImageGallery images={(task as any).images} alt={task.title} />
+            </div>
+          )}
 
           {/* Info bar 3 columns */}
           <div className="mx-4 mb-3 md:mx-6 md:mb-5 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-100 dark:border-gray-700">

--- a/apps/web/src/pages/TaskDetail/components/TaskLocationMap.tsx
+++ b/apps/web/src/pages/TaskDetail/components/TaskLocationMap.tsx
@@ -46,6 +46,9 @@ export const TaskLocationMap = ({ task }: TaskLocationMapProps) => {
           style={{ height: '100%', width: '100%' }}
           scrollWheelZoom={false}
           zoomControl={false}
+          dragging={false}
+          doubleClickZoom={false}
+          touchZoom={false}
         >
           <TileLayer
             attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'


### PR DESCRIPTION
## Changes

### 1. ImageGallery on TaskDetail + OfferingDetail
- New `ImageGallery` component (horizontal scroll, fullscreen lightbox, keyboard/swipe nav)
- Wired into both detail pages after description

### 2. ImagePicker on CreateOffering with dark mode
- New `ImagePicker` component with full dark mode support
- Wired into CreateOffering form

### 3. Map touch hijacking fix
- `dragging={false}`, `doubleClickZoom={false}`, `touchZoom={false}` on TaskLocationMap + OfferingLocationMap

### 4. Title overflow fix
- `line-clamp-3` on mobile titles in TaskDetail + OfferingHeader

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/162?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->