### PR TITLE
chore: remove duplicate types from shared package (Phase 2 of #166)

### DIFF
--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,100 +1,14 @@
-// User types
-export interface User {
-  id: number;
-  email: string;
-  name: string;
-  phone?: string;
-  created_at: string;
-}
+// Types barrel file
+// 
+// All shared types are now defined in api/types.ts and re-exported
+// through the api barrel (src/api/index.ts → src/index.ts).
+//
+// This file previously contained duplicate/outdated versions of:
+//   User, Listing, LoginCredentials, RegisterData, CreateListingData,
+//   ApiError, PaginatedResponse, AuthState, ListingCategory,
+//   ListingCondition, ListingsFilter, ApiResponse
+//
+// None of those were imported by the web app from this file.
+// See api/types.ts for the canonical type definitions.
 
-export interface AuthState {
-  user: User | null;
-  token: string | null;
-  isAuthenticated: boolean;
-  isLoading: boolean;
-}
-
-export interface LoginCredentials {
-  email: string;
-  password: string;
-}
-
-export interface RegisterData {
-  email: string;
-  password: string;
-  name: string;
-  phone?: string;
-}
-
-// Listing types
-export interface Listing {
-  id: number;
-  title: string;
-  description: string;
-  price: number;
-  category: ListingCategory;
-  condition: ListingCondition;
-  location: string;
-  images?: string[];
-  user_id: number;
-  user?: User;
-  created_at: string;
-  updated_at: string;
-  views?: number;
-  is_active: boolean;
-}
-
-export type ListingCategory = 
-  | 'electronics'
-  | 'vehicles'
-  | 'property'
-  | 'furniture'
-  | 'clothing'
-  | 'sports'
-  | 'books'
-  | 'other';
-
-export type ListingCondition = 
-  | 'new'
-  | 'like_new'
-  | 'good'
-  | 'fair'
-  | 'poor';
-
-export interface CreateListingData {
-  title: string;
-  description: string;
-  price: number;
-  category: ListingCategory;
-  condition: ListingCondition;
-  location: string;
-}
-
-export interface ListingsFilter {
-  category?: ListingCategory;
-  condition?: ListingCondition;
-  min_price?: number;
-  max_price?: number;
-  location?: string;
-  search?: string;
-}
-
-// API Response types
-export interface ApiResponse<T> {
-  data: T;
-  message?: string;
-}
-
-export interface ApiError {
-  error: string;
-  message: string;
-  status: number;
-}
-
-export interface PaginatedResponse<T> {
-  data: T[];
-  total: number;
-  page: number;
-  per_page: number;
-  total_pages: number;
-}
+export {};


### PR DESCRIPTION
## Phase 2 of #166 — Fix duplicate types in shared package

### Problem

`packages/shared` had two files exporting the same interface names:

| Interface | `types/index.ts` | `api/types.ts` |
|-----------|-----------------|----------------|
| `User` | 5 fields (basic) | 20 fields (full profile) |
| `Listing` | 12 fields | 25+ fields (seller info, coords) |
| `RegisterData` | uses `name` | uses `username` (matches backend) |
| `LoginCredentials` | identical | identical |
| `CreateListingData` | 6 fields | 11 fields |
| `ApiError` | different shape | different shape |
| `PaginatedResponse` | `data[]` / `total_pages` | `items[]` / `pages` |

The barrel export order (`export * from './api'` then `export * from './types'`) meant the **simpler, outdated** `types/index.ts` versions won at resolve time.

### What changed

- Replaced `packages/shared/src/types/index.ts` with an empty `export {}` and a documentation comment explaining why
- Zero changes to any other file — the `api/types.ts` versions now seamlessly take over

### Verification

**Types only in `types/index.ts` (all unused):**
- `AuthState` — 0 imports
- `ListingCategory` — 0 imports
- `ListingCondition` — 0 imports
- `ListingsFilter` — 0 imports
- `ApiResponse` — 0 imports

**Duplicated types actually imported by web app:**
- `Listing` (4×) — `api/types.ts` version is a superset, non-breaking
- `LoginCredentials` (1×) — identical in both files
- `RegisterData` (1×) — `api/types.ts` uses `username` (matches backend)

**Method:** Full `Get-ChildItem | Select-String` scan of `apps/web/src/**/*.ts(x)` + GitHub code search of `packages/shared/src/` internals.

### Risk

Low. The only behavioral change is that `Listing` and `RegisterData` types become **more complete** (more optional fields), which is non-breaking in TypeScript.

Closes Phase 2 checklist items in #166.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/168?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->