### PR TITLE
Fix: Shared task links redirect directly to TaskDetail page

### DIFF
--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -1,38 +1,34 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuthStore } from '@marketplace/shared';
 import MapHomePage from './MapHomePage';
 
 /**
  * Home page routing logic:
- * - NOT authenticated + no ?task= → Redirect to /welcome (landing page)
- * - NOT authenticated + ?task=ID  → Show map as guest (shared link preview)
- * - Authenticated → Show map (may auto-select a shared task via ?task=ID)
- *
- * IMPORTANT: We store the shared-task check in a ref because
- * MobileTasksView removes ?task= from the URL after reading it.
- * Without the ref, the re-render would see hasSharedTask=false
- * and redirect the guest to /welcome.
+ * - ?task=ID present        → Redirect to /tasks/ID (shared link)
+ * - NOT authenticated       → Redirect to /welcome (landing page)
+ * - Authenticated           → Show map
  */
 export default function Home() {
   const { isAuthenticated } = useAuthStore();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
 
-  // Capture once on mount — survives URL param removal by child components
-  const isGuestSharedTask = useRef(
-    !isAuthenticated && !!new URLSearchParams(window.location.search).get('task')
-  );
-
-  const allowGuest = isGuestSharedTask.current;
+  // Shared task deep link — redirect straight to the detail page
+  useEffect(() => {
+    const taskId = searchParams.get('task');
+    if (taskId) {
+      navigate(`/tasks/${taskId}`, { replace: true });
+    }
+  }, [searchParams, navigate]);
 
   useEffect(() => {
-    if (!isAuthenticated && !allowGuest) {
+    if (!isAuthenticated && !searchParams.get('task')) {
       navigate('/welcome', { replace: true });
     }
-  }, [isAuthenticated, navigate, allowGuest]);
+  }, [isAuthenticated, navigate, searchParams]);
 
-  if (!isAuthenticated && !allowGuest) {
+  if (!isAuthenticated) {
     return null;
   }
 


### PR DESCRIPTION
## Problem

When a job/task is shared via a link like `https://www.kolab.lv/?task=1`, the user lands on the Home/Map page and sees a small `JobPreviewCard` overlay instead of being taken directly to the full Task Detail page. They have to manually tap "View Details" to get there.

## Fix

In `Home.tsx`, added an early redirect: if `?task=ID` is present in the URL, immediately navigate to `/tasks/ID` before rendering MapHomePage.

### What changed
- **`apps/web/src/pages/Home.tsx`** — simplified to redirect `?task=ID` → `/tasks/ID` immediately
- Removed the `useRef` workaround for guest shared task access (no longer needed since we redirect before rendering)

### Why this works
- The `/tasks/:id` route already exists and renders the full `TaskDetail` component
- The `/tasks/:id` route is **not** wrapped in `<ProtectedRoute>`, so guests can access it
- No changes needed to `App.tsx` routing or `MobileTasksView`

### Before → After
| | Before | After |
|---|---|---|
| Shared link | Shows map + small preview card | Goes directly to full Task Detail page |
| User action needed | Tap "View Details" | None — lands on detail immediately |

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/175?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->