### PR TITLE
Fix: Remove duplicate profile fields on desktop edit

### DIFF
--- a/apps/web/src/pages/Profile/Profile.tsx
+++ b/apps/web/src/pages/Profile/Profile.tsx
@@ -95,6 +95,11 @@ const Profile = () => {
     setFormData(prev => ({ ...prev, ...updates }));
   };
 
+  const handleStartEditing = () => {
+    setEditing(true);
+    setActiveTab('about');
+  };
+
   if (loading) {
     return <LoadingState />;
   }
@@ -195,7 +200,7 @@ const Profile = () => {
     );
   }
 
-  // Desktop layout — unchanged
+  // Desktop layout
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950 py-6 animate-page-enter">
       <div className="max-w-4xl mx-auto px-4">
@@ -205,7 +210,7 @@ const Profile = () => {
           editing={editing}
           saving={saving}
           totalTasksCompleted={totalTasksCompleted}
-          onEdit={() => setEditing(true)}
+          onEdit={handleStartEditing}
           onCancel={() => setEditing(false)}
           onSave={handleSave}
           onChangeAvatar={() => avatarPicker.setShowAvatarPicker(true)}
@@ -231,18 +236,6 @@ const Profile = () => {
           onClose={() => setShowHowItWorks(false)}
           showCheckboxes={false}
         />
-
-        {editing && (
-          <div className="mb-4">
-            <AboutTab
-              profile={profile}
-              editing={editing}
-              formData={formData}
-              onChange={handleChange}
-              onFormDataChange={handleFormDataChange}
-            />
-          </div>
-        )}
 
         <ProfileTabs
           activeTab={activeTab}


### PR DESCRIPTION
## Problem

When clicking "Edit Profile" on desktop, the same form fields (name, phone, description, skills, etc.) appear **twice** — once above the tab bar and once inside the "Par mani" (About) tab.

## Root Cause

In `Profile.tsx` desktop layout, two `<AboutTab>` instances rendered simultaneously:
1. `{editing && <AboutTab>}` — above `<ProfileTabs>` 
2. `{activeTab === 'about' && <AboutTab>}` — below tabs

Both conditions were true at the same time.

## Fix

- Removed the extra `{editing && <AboutTab>}` block above the tabs
- Added `handleStartEditing()` that sets `editing=true` AND switches to the `'about'` tab, so the edit form is always visible in the right place
- Mobile layout unchanged (it was already correct)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/177?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->