### PR TITLE
feat: remove listings/favorites, add Marketplace section to Settings

### DIFF
--- a/apps/web/src/components/Layout/Header/ProfileDropdown.tsx
+++ b/apps/web/src/components/Layout/Header/ProfileDropdown.tsx
@@ -114,18 +114,6 @@ export const ProfileDropdown = ({ user, notifications, onLogout }: ProfileDropdo
             </Link>
             
             <Link
-              to="/profile?tab=listings"
-              onClick={() => setIsOpen(false)}
-              className="flex items-center gap-3 px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
-              role="menuitem"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-              </svg>
-              {t('menu.myListings')}
-            </Link>
-            
-            <Link
               to="/messages"
               onClick={() => setIsOpen(false)}
               className="flex items-center gap-3 px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"

--- a/apps/web/src/pages/Profile/Profile.tsx
+++ b/apps/web/src/pages/Profile/Profile.tsx
@@ -10,7 +10,6 @@ import {
 } from './components';
 import {
   AboutTab,
-  ListingsTab,
   OfferingsTab,
   TasksTab,
   ReviewsTab,
@@ -262,14 +261,6 @@ const Profile = () => {
             formData={formData}
             onChange={handleChange}
             onFormDataChange={handleFormDataChange}
-          />
-        )}
-
-        {activeTab === 'listings' && (
-          <ListingsTab
-            listings={myListings}
-            loading={listingsLoading}
-            onDelete={actions.handleDeleteListing}
           />
         )}
 

--- a/apps/web/src/pages/Profile/components/ProfileHeader/ProfileHeader.tsx
+++ b/apps/web/src/pages/Profile/components/ProfileHeader/ProfileHeader.tsx
@@ -276,18 +276,6 @@ export const ProfileHeader = ({
           >
             👋 {t('profile.quickActions.offerService')}
           </Link>
-          <Link
-            to="/listings/create"
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-purple-50 dark:bg-purple-900/20 text-purple-700 dark:text-purple-400 rounded-full text-sm font-medium hover:bg-purple-100 dark:hover:bg-purple-900/30 transition-colors"
-          >
-            🏷️ {t('profile.quickActions.sellItem')}
-          </Link>
-          <Link
-            to="/favorites"
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-pink-50 dark:bg-pink-900/20 text-pink-700 dark:text-pink-400 rounded-full text-sm font-medium hover:bg-pink-100 dark:hover:bg-pink-900/30 transition-colors"
-          >
-            ❤️ {t('profile.quickActions.favorites')}
-          </Link>
         </div>
       )}
     </div>

--- a/apps/web/src/pages/Profile/components/ProfileTabs/ProfileTabs.tsx
+++ b/apps/web/src/pages/Profile/components/ProfileTabs/ProfileTabs.tsx
@@ -58,10 +58,6 @@ export const ProfileTabs = ({
         {t('profile.tabs.services')} {hasContent.offerings && <span className="text-gray-400 dark:text-gray-500">({counts.offerings})</span>}
       </button>
       
-      <button onClick={() => onTabChange('listings')} className={tabClass('listings')}>
-        {t('profile.tabs.listings')} {hasContent.listings && <span className="text-gray-400 dark:text-gray-500">({counts.listings})</span>}
-      </button>
-      
       {(hasContent.reviews || !viewOnly) && (
         <button onClick={() => onTabChange('reviews')} className={tabClass('reviews')}>
           {t('profile.tabs.reviews')} ({counts.reviews})

--- a/apps/web/src/pages/Profile/components/tabs/SettingsTab.tsx
+++ b/apps/web/src/pages/Profile/components/tabs/SettingsTab.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ThemeSettings } from './settings/ThemeSettings';
 import { LanguageSettings } from './settings/LanguageSettings';
@@ -7,6 +8,66 @@ import { LogoutSection } from './settings/LogoutSection';
 interface SettingsTabProps {
   onHowItWorks?: () => void;
 }
+
+const MarketplaceTeaser = () => {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
+      <div className="px-6 py-4">
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="w-full text-left bg-gradient-to-r from-purple-50 via-indigo-50 to-blue-50 dark:from-purple-900/20 dark:via-indigo-900/20 dark:to-blue-900/20 rounded-xl border border-purple-100/80 dark:border-purple-800/40 px-4 py-3.5 transition-all hover:shadow-sm active:scale-[0.99]"
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-purple-500 to-indigo-500 flex items-center justify-center shadow-sm">
+                <span className="text-white text-lg">📦</span>
+              </div>
+              <div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+                    {t('profile.listings.comingSoonTitle', 'Marketplace')}
+                  </span>
+                  <span className="px-1.5 py-0.5 bg-gradient-to-r from-purple-500 to-indigo-500 text-white text-[9px] rounded-full font-bold uppercase tracking-wider">
+                    {t('profile.listings.comingSoonBadge', 'Soon')}
+                  </span>
+                </div>
+                <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">
+                  {t('profile.listings.comingSoonTagline', 'Buy & sell locally')}
+                </p>
+              </div>
+            </div>
+            <svg
+              className={`w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </div>
+
+          {expanded && (
+            <div className="mt-3 pt-3 border-t border-purple-100/60 dark:border-purple-800/30">
+              <p className="text-xs text-gray-600 dark:text-gray-400 leading-relaxed">
+                {t('profile.listings.comingSoonDescription', 'Soon you\'ll be able to list products and items for sale right from your profile. Handmade goods, second-hand items, and more.')}
+              </p>
+              <div className="flex flex-wrap gap-1.5 mt-2">
+                {['🏷️', '🛍️', '🎨', '📱', '🪑', '👕'].map((emoji, i) => (
+                  <span key={i} className="w-7 h-7 rounded-full bg-white/80 dark:bg-gray-800/80 flex items-center justify-center text-sm shadow-sm">
+                    {emoji}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+};
 
 export const SettingsTab = ({ onHowItWorks }: SettingsTabProps) => {
   const { t } = useTranslation();
@@ -41,6 +102,8 @@ export const SettingsTab = ({ onHowItWorks }: SettingsTabProps) => {
           </div>
         </div>
       )}
+
+      <MarketplaceTeaser />
 
       <ThemeSettings />
       <LanguageSettings />


### PR DESCRIPTION
## Changes

### Removed (not yet implemented features)
- **"Sell Item"** and **"Favorites"** quick action buttons from desktop ProfileHeader
- **"Listings"** tab from ProfileTabs
- **"My Listings"** (Mani sludinājumi) menu item from the header ProfileDropdown
- Listings tab rendering from Profile.tsx

### Added
- **Marketplace "Coming Soon" teaser** in the Settings tab — expandable banner with the same gradient style as the mobile `MobileListingsTeaser`, advertising the upcoming marketplace feature

### Notes
- `ActiveTab` type still includes `'listings'` for backwards compatibility (old bookmarked URLs won't crash)
- Listings data hooks and `ListingsTab` component are kept in the codebase for when the feature is ready
- ProfileDropdown also includes the dark theme fix from PR #180

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/181?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->