### PR TITLE
fix(i18n): correct LV handyman translation — "Saimnieks" → "Meistars"

### DIFF
--- a/packages/shared/src/i18n/locales/lv/tasks.json
+++ b/packages/shared/src/i18n/locales/lv/tasks.json
@@ -160,7 +160,7 @@
     "cleaning": "Uzkop\u0161ana",
     "moving": "P\u0101rv\u0101k\u0161an\u0101s un cel\u0161ana",
     "assembly": "Mont\u0101\u017ea",
-    "handyman": "Saimnieks",
+    "handyman": "Meistars",
     "plumbing": "Santehnika",
     "electrical": "Elektri\u0137is",
     "painting": "Kr\u0101so\u0161ana",


### PR DESCRIPTION
## Problem

The Latvian translation for the `handyman` category in `tasks.json` was set to **"Saimnieks"**, which means "owner/host/landlord" — not a handyman/craftsman.

This affected the category picker on the Create Task page and anywhere else that reads from `tasks.categories.handyman`.

## Fix

- Changed `tasks.categories.handyman` from `"Saimnieks"` → `"Meistars"` (craftsman/handyman)

## Files Changed

- `packages/shared/src/i18n/locales/lv/tasks.json` — fixed the `handyman` category label

## Notes

`common.json` already had the correct translation (`"Meistars"`), so this brings `tasks.json` in line with it.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/183?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->