### PR TITLE
fix(i18n): translate category labels directly in CompactFilterBar

### DIFF
--- a/apps/web/src/components/ui/CompactFilterBar.tsx
+++ b/apps/web/src/components/ui/CompactFilterBar.tsx
@@ -105,6 +105,11 @@ const CompactFilterBar = ({
     return `${prefix}: €${filters.minPrice}-${filters.maxPrice}`;
   };
 
+  // Translate a category value to its localized label
+  const translateCategory = (value: string, fallback: string) => {
+    return t(`tasks.categories.${value}`, fallback);
+  };
+
   // Get display label for category
   const getCategoryLabel = () => {
     const prefix = t('filters.category', 'Category');
@@ -112,7 +117,7 @@ const CompactFilterBar = ({
       return prefix;
     }
     const cat = categoryOptions.find(c => c.value === filters.category);
-    return `${prefix}: ${cat ? cat.label : filters.category}`;
+    return `${prefix}: ${cat ? translateCategory(cat.value, cat.label) : filters.category}`;
   };
 
   // Get display label for posted date
@@ -311,7 +316,7 @@ const CompactFilterBar = ({
                     `}
                   >
                     {cat.icon && <span className="mr-2">{cat.icon}</span>}
-                    {cat.label}
+                    {translateCategory(cat.value, cat.label)}
                   </button>
                 ))}
               </div>


### PR DESCRIPTION
## Problem
Category dropdown in the filter bar shows English names ("Cleaning", "Outdoor", etc.) even when the app language is set to Latvian. All other filter labels (Rādiuss, Kategorija, Publicēts, Cena) translate correctly.

## Root Cause
The parent component (`Tasks.tsx`) was passing pre-translated labels via `getCategoryOptions(t)`, but the `t()` call there wasn't resolving translations properly. Meanwhile, the `CompactFilterBar` component's own `t()` function works perfectly — proven by all other filter labels translating correctly.

## Fix
Instead of relying on pre-translated labels from the parent, use `t()` **directly inside `CompactFilterBar`** — the exact same `t()` that already translates "Rādiuss", "Kategorija", etc.

Two changes in `CompactFilterBar.tsx`:
1. Added `translateCategory()` helper: `t('tasks.categories.${value}', fallback)`
2. Category dropdown items: `{cat.label}` → `{translateCategory(cat.value, cat.label)}`
3. Category button label: same pattern in `getCategoryLabel()`

No new translation keys needed — uses the existing `tasks.categories.*` keys from `lv/tasks.json`.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-frontend/185?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->