### PR TITLE
fix: handle Firebase IndexedDB AbortError on iOS Safari

### DIFF
--- a/apps/web/src/lib/firebase.ts
+++ b/apps/web/src/lib/firebase.ts
@@ -1,5 +1,12 @@
 import { initializeApp } from 'firebase/app'
-import { getAuth, RecaptchaVerifier, signInWithPhoneNumber } from 'firebase/auth'
+import {
+  getAuth,
+  RecaptchaVerifier,
+  signInWithPhoneNumber,
+  indexedDBLocalPersistence,
+  browserLocalPersistence,
+  setPersistence,
+} from 'firebase/auth'
 import type { ConfirmationResult } from 'firebase/auth'
 
 const firebaseConfig = {
@@ -15,6 +22,14 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = initializeApp(firebaseConfig)
 export const auth = getAuth(app)
+
+// Gracefully handle iOS Safari IndexedDB AbortError.
+// Firebase defaults to indexedDB persistence which fails in iOS Private Browsing,
+// in-app browsers (Instagram, Facebook), and when racing with SW registration.
+setPersistence(auth, indexedDBLocalPersistence).catch(() => {
+  // Fallback to localStorage when IndexedDB is blocked/aborted
+  return setPersistence(auth, browserLocalPersistence)
+})
 
 // Re-export Firebase Auth types and functions for use in components
 export { RecaptchaVerifier, signInWithPhoneNumber }

--- a/apps/web/src/lib/sentry.ts
+++ b/apps/web/src/lib/sentry.ts
@@ -27,6 +27,10 @@ export function initSentry() {
       // iOS aggressively kills IndexedDB connections when backgrounded
       'Connection to Indexed Database server lost',
       'IndexedDB',
+      // Firebase IndexedDB AbortError on iOS Safari (idb-open)
+      // Triggered in Private Browsing, in-app browsers, or SW registration race
+      'The operation was aborted',
+      /idb-open/,
       // reCAPTCHA timeout — Firebase SDK rejects with string "Timeout" (KOLAB-WEB-9, KOLAB-WEB-8)
       /^Timeout/,
       /Non-Error promise rejection captured with value: Timeout/,


### PR DESCRIPTION
## Problem

Firebase throws an unhandled `AbortError` when trying to open IndexedDB on iOS Safari (iOS 18.6.2, iPhone). Reported in Sentry on the `/welcome` page:

```
@firebase/app: Firebase: Error thrown when opening IndexedDB.
Original error: The operation was aborted. (app/idb-open)
```

This happens when:
- User is in **Private Browsing** mode (Safari restricts IndexedDB)
- Page is loaded in an **in-app browser** (Instagram, Facebook, etc.)
- iOS kills the IDB connection during **Service Worker registration** race condition

## Changes

### `apps/web/src/lib/firebase.ts`
- Added `setPersistence()` call that tries `indexedDBLocalPersistence` first
- Falls back to `browserLocalPersistence` (localStorage) if IndexedDB is blocked/aborted
- No changes to existing function signatures or exports

### `apps/web/src/lib/sentry.ts`
- Added `'The operation was aborted'` and `/idb-open/` to `ignoreErrors` to suppress remaining noise from unfixable edge cases

## Why this works

Firebase Auth defaults to IndexedDB for persistence. On iOS Safari in restricted contexts, this silently fails with an `AbortError`. By explicitly setting persistence with a catch fallback, we ensure auth still works (via localStorage) even when IndexedDB is unavailable. Users in these environments will simply not persist auth across full tab closures, which is acceptable.

## Testing

- [ ] Verify on iOS Safari (normal mode) — should use IndexedDB as before
- [ ] Verify on iOS Safari (Private Browsing) — should fall back to localStorage without errors
- [ ] Verify phone auth flow still works on desktop browsers
- [ ] Confirm Sentry stops receiving `idb-open` errors after deploy